### PR TITLE
Update deps for Dome: use msgs6, transport9, sdf10

### DIFF
--- a/.github/ci-bionic/after_make.sh
+++ b/.github/ci-bionic/after_make.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -l
+
+set -x
+
+# Install (needed for some tests)
+make install
+
+Xvfb :1 -screen 0 1280x1024x24 &
+export DISPLAY=:1.0
+export RENDER_ENGINE_VALUES=ogre2
+export MESA_GL_VERSION_OVERRIDE=3.3

--- a/.github/ci-bionic/after_make.sh
+++ b/.github/ci-bionic/after_make.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -l
 
 set -x
+set -e
 
 # Install (needed for some tests)
 make install

--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -18,11 +18,11 @@ jobs:
             libignition-cmake2-dev
             libignition-common3-dev
             libignition-math6-dev
-            libignition-msgs5-dev
+            libignition-msgs6-dev
             libignition-tools-dev
             libignition-plugin-dev
-            libignition-transport8-dev
-            libsdformat9-dev
+            libignition-transport9-dev
+            libsdformat10-dev
             libogre-1.9-dev
             libogre-2.1-dev
             libglew-dev

--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -31,4 +31,5 @@ jobs:
             libxmu-dev
             libxi-dev
             uuid-dev
+            xvfb
           codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ set(IGN_COMMON_VER ${ignition-common3_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-transport
-ign_find_package(ignition-transport8 REQUIRED)
-set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
+ign_find_package(ignition-transport9 REQUIRED)
+set(IGN_TRANSPORT_VER ${ignition-transport9_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-rendering
@@ -75,8 +75,8 @@ endif()
 
 #--------------------------------------
 # Find ignition-msgs
-ign_find_package(ignition-msgs5 REQUIRED)
-set(IGN_MSGS_VER ${ignition-msgs5_VERSION_MAJOR})
+ign_find_package(ignition-msgs6 REQUIRED)
+set(IGN_MSGS_VER ${ignition-msgs6_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-plugin
@@ -85,8 +85,8 @@ set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 
 #--------------------------------------
 # Find SDFormat
-ign_find_package(sdformat9 VERSION 9.2 REQUIRED)
-set(SDF_VER ${sdformat9_VERSION_MAJOR})
+ign_find_package(sdformat10 REQUIRED)
+set(SDF_VER ${sdformat10_VERSION_MAJOR})
 
 set(IGN_SENSORS_PLUGIN_PATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
 

--- a/test/integration/depth_camera_plugin.cc
+++ b/test/integration/depth_camera_plugin.cc
@@ -432,7 +432,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
       for (unsigned int j = 0; j < depthSensor->ImageWidth(); ++j)
       {
         float d = g_depthBuffer[step + j];
-        EXPECT_FLOAT_EQ(expectedDepth, d);
+        EXPECT_NEAR(expectedDepth, d, DOUBLE_TOL);
       }
     }
   }
@@ -445,7 +445,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
       for (unsigned int j = 0; j < depthSensor->ImageWidth(); ++j)
       {
         float x = g_pointsXYZBuffer[step + j*3];
-        EXPECT_FLOAT_EQ(expectedDepth, x);
+        EXPECT_NEAR(expectedDepth, x, DOUBLE_TOL);
       }
     }
 


### PR DESCRIPTION
As part of the works of ignition-tooling/gazebodistro#5 bump the use of msgs to major version 6, transport to 9, sdf to 10.