### PR TITLE
Make topics valid

### DIFF
--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -l
+
+set -x
+set -e
+
+# Install (needed for some tests)
+make install
+
+Xvfb :1 -screen 0 1280x1024x24 &
+export DISPLAY=:1.0
+export RENDER_ENGINE_VALUES=ogre2
+export MESA_GL_VERSION_OVERRIDE=3.3

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -7,3 +7,4 @@ libignition-rendering2-dev
 libignition-tools-dev
 libignition-transport7-dev
 libsdformat8-dev
+xvfb

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,0 +1,9 @@
+libignition-cmake2-dev
+libignition-common3-dev
+libignition-math6-dev
+libignition-msgs4-dev
+libignition-plugin-dev
+libignition-rendering2-dev
+libignition-tools-dev
+libignition-transport7-dev
+libsdformat8-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-name: Ubuntu Bionic CI
+name: Ubuntu CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   bionic-ci:
@@ -9,9 +9,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Bionic CI
+      - name: Compile and test
         id: ci
-        uses: ignition-tooling/ubuntu-bionic-ci-action@master
+        uses: ignition-tooling/action-ignition-ci@master
         with:
           apt-dependencies: 'libignition-cmake2-dev libignition-common3-dev libignition-math6-dev libignition-msgs4-dev libignition-rendering2-dev libignition-transport7-dev libignition-tools-dev libignition-plugin-dev libsdformat8-dev'
           codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(IGN_COMMON_VER ${ignition-common3_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-transport
-ign_find_package(ignition-transport7 REQUIRED)
+ign_find_package(ignition-transport7 REQUIRED VERSION 7.5)
 set(IGN_TRANSPORT_VER ${ignition-transport7_VERSION_MAJOR})
 
 #--------------------------------------

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -132,6 +132,11 @@ namespace ignition
       /// \return Topic sensor publishes data to
       public: std::string Topic() const;
 
+      /// \brief Set topic where sensor data is published.
+      /// \param[in] _topic Topic sensor publishes data to.
+      /// \return True if a valid topic was set.
+      public: bool SetTopic(const std::string &_topic);
+
       /// \brief Get parent link of the sensor.
       /// \return Parent link of sensor.
       public: std::string Parent() const;

--- a/src/AirPressureSensor.cc
+++ b/src/AirPressureSensor.cc
@@ -104,7 +104,8 @@ bool AirPressureSensor::Load(const sdf::Sensor &_sdf)
     this->SetTopic("/air_pressure");
 
   this->dataPtr->pub =
-      this->dataPtr->node.Advertise<ignition::msgs::FluidPressure>(this->Topic());
+      this->dataPtr->node.Advertise<ignition::msgs::FluidPressure>(
+      this->Topic());
 
   if (!this->dataPtr->pub)
   {

--- a/src/AirPressureSensor.cc
+++ b/src/AirPressureSensor.cc
@@ -100,16 +100,15 @@ bool AirPressureSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
-  std::string topic = this->Topic();
-  if (topic.empty())
-    topic = "/air_pressure";
+  if (this->Topic().empty())
+    this->SetTopic("/air_pressure");
 
   this->dataPtr->pub =
-      this->dataPtr->node.Advertise<ignition::msgs::FluidPressure>(topic);
+      this->dataPtr->node.Advertise<ignition::msgs::FluidPressure>(this->Topic());
 
   if (!this->dataPtr->pub)
   {
-    ignerr << "Unable to create publisher on topic[" << topic << "].\n";
+    ignerr << "Unable to create publisher on topic[" << this->Topic() << "].\n";
     return false;
   }
 

--- a/src/AltimeterSensor.cc
+++ b/src/AltimeterSensor.cc
@@ -88,16 +88,15 @@ bool AltimeterSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
-  std::string topic = this->Topic();
-  if (topic.empty())
-    topic = "/altimeter";
+  if (this->Topic().empty())
+    this->SetTopic("/altimeter");
 
   this->dataPtr->pub =
-      this->dataPtr->node.Advertise<ignition::msgs::Altimeter>(topic);
+      this->dataPtr->node.Advertise<ignition::msgs::Altimeter>(this->Topic());
 
   if (!this->dataPtr->pub)
   {
-    ignerr << "Unable to create publisher on topic[" << topic << "].\n";
+    ignerr << "Unable to create publisher on topic[" << this->Topic() << "].\n";
     return false;
   }
 

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -234,6 +234,9 @@ bool CameraSensor::Load(const sdf::Sensor &_sdf)
 
   this->dataPtr->sdfSensor = _sdf;
 
+  if (this->Topic().empty())
+    this->SetTopic("/camera");
+
   this->dataPtr->pub =
       this->dataPtr->node.Advertise<ignition::msgs::Image>(
           this->Topic());

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -188,7 +188,7 @@ TEST(Camera_TEST, Topic)
 
   // Convert to valid topic
   {
-    const std::string topic = "/topic with  spaces/@~characters//";
+    const std::string topic = "/topic with spaces/@~characters//";
     auto cameraSdf = CameraToSdf(type, name, updateRate, topic, alwaysOn,
         visualize);
 
@@ -201,7 +201,7 @@ TEST(Camera_TEST, Topic)
     auto camera = dynamic_cast<ignition::sensors::CameraSensor *>(sensor);
     ASSERT_NE(nullptr, camera);
 
-    EXPECT_EQ("/topic_with__spaces/characters", camera->Topic());
+    EXPECT_EQ("/topic_with_spaces/characters", camera->Topic());
   }
 
   // Invalid topic

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -252,6 +252,9 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
 
   this->dataPtr->sdfSensor = _sdf;
 
+  if (this->Topic().empty())
+    this->SetTopic("/camera/depth");
+
   this->dataPtr->pub =
       this->dataPtr->node.Advertise<ignition::msgs::Image>(
           this->Topic());

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -121,14 +121,16 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
         std::bind(&GpuLidarSensor::SetScene, this, std::placeholders::_1));
 
   // Create the point cloud publisher
+  this->SetTopic(this->Topic() + "/points");
+
   this->dataPtr->pointPub =
       this->dataPtr->node.Advertise<ignition::msgs::PointCloudPacked>(
-          this->Topic() + "/points");
+          this->Topic());
 
   if (!this->dataPtr->pointPub)
   {
     ignerr << "Unable to create publisher on topic["
-      << this->Topic() + "/points" << "].\n";
+      << this->Topic() << "].\n";
     return false;
   }
 

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -104,16 +104,15 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
-  std::string topic = this->Topic();
-  if (topic.empty())
-    topic = "/imu";
+  if (this->Topic().empty())
+    this->SetTopic("/imu");
 
   this->dataPtr->pub =
-      this->dataPtr->node.Advertise<ignition::msgs::IMU>(topic);
+      this->dataPtr->node.Advertise<ignition::msgs::IMU>(this->Topic());
 
   if (!this->dataPtr->pub)
   {
-    ignerr << "Unable to create publisher on topic[" << topic << "].\n";
+    ignerr << "Unable to create publisher on topic[" << this->Topic() << "].\n";
     return false;
   }
 

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -104,6 +104,9 @@ bool Lidar::Load(const sdf::Sensor &_sdf)
   }
 
   // Register publisher
+  if (this->Topic().empty())
+    this->SetTopic("/lidar");
+
   this->dataPtr->pub =
       this->dataPtr->node.Advertise<ignition::msgs::LaserScan>(
         this->Topic());

--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -103,16 +103,16 @@ bool LogicalCameraSensor::Load(sdf::ElementPtr _sdf)
   if (!Sensor::Load(_sdf))
     return false;
 
-  std::string topic = this->Topic();
-  if (topic.empty())
-    topic = "/logical_camera";
+  if (this->Topic().empty())
+    this->SetTopic("/logical_camera");
 
   this->dataPtr->pub =
-      this->dataPtr->node.Advertise<ignition::msgs::LogicalCameraImage>(topic);
+      this->dataPtr->node.Advertise<ignition::msgs::LogicalCameraImage>(
+      this->Topic());
 
   if (!this->dataPtr->pub)
   {
-    ignerr << "Unable to create publisher on topic[" << topic << "].\n";
+    ignerr << "Unable to create publisher on topic[" << this->Topic() << "].\n";
     return false;
   }
 

--- a/src/MagnetometerSensor.cc
+++ b/src/MagnetometerSensor.cc
@@ -92,16 +92,16 @@ bool MagnetometerSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
-  std::string topic = this->Topic();
-  if (topic.empty())
-    topic = "/magnetometer";
+  if (this->Topic().empty())
+    this->SetTopic("/magnetometer");
 
   this->dataPtr->pub =
-      this->dataPtr->node.Advertise<ignition::msgs::Magnetometer>(topic);
+      this->dataPtr->node.Advertise<ignition::msgs::Magnetometer>(
+      this->Topic());
 
   if (!this->dataPtr->pub)
   {
-    ignerr << "Unable to create publisher on topic[" << topic << "].\n";
+    ignerr << "Unable to create publisher on topic[" << this->Topic() << "].\n";
     return false;
   }
 

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -21,6 +21,7 @@
 #include <ignition/sensors/Manager.hh>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
+#include <ignition/transport/TopicUtils.hh>
 
 using namespace ignition::sensors;
 
@@ -29,6 +30,11 @@ class ignition::sensors::SensorPrivate
 {
   /// \brief Populates fields from a <sensor> DOM
   public: bool PopulateFromSDF(const sdf::Sensor &_sdf);
+
+  /// \brief Set topic where sensor data is published.
+  /// \param[in] _topic Topic sensor publishes data to.
+  /// \return True if a valid topic was set.
+  public: bool SetTopic(const std::string &_topic);
 
   /// \brief id given to sensor when constructed
   public: SensorId id;
@@ -88,7 +94,11 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
 
   // \todo(nkoenig) how to use frame?
   this->name = _sdf.Name();
-  this->topic = _sdf.Topic();
+  if (!_sdf.Topic().empty())
+  {
+    if (!this->SetTopic(_sdf.Topic()))
+      return false;
+  }
   this->pose = _sdf.Pose();
   this->updateRate = _sdf.UpdateRate();
   return true;
@@ -155,6 +165,26 @@ std::string Sensor::Name() const
 std::string Sensor::Topic() const
 {
   return this->dataPtr->topic;
+}
+
+//////////////////////////////////////////////////
+bool Sensor::SetTopic(const std::string &_topic)
+{
+  return this->dataPtr->SetTopic(_topic);
+}
+
+//////////////////////////////////////////////////
+bool SensorPrivate::SetTopic(const std::string &_topic)
+{
+  auto validTopic = transport::TopicUtils::AsValidTopic(_topic);
+  if (validTopic.empty())
+  {
+    ignerr << "Failed to set sensor topic [" << _topic << "]" << std::endl;
+    return false;
+  }
+
+  this->topic = validTopic;
+  return true;
 }
 
 //////////////////////////////////////////////////

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -63,6 +63,7 @@ TEST(Sensor_TEST, Sensor)
   EXPECT_EQ(nullptr, sensor.SDF());
 }
 
+//////////////////////////////////////////////////
 TEST(Sensor_TEST, AddSequence)
 {
   TestSensor sensor;
@@ -95,6 +96,21 @@ TEST(Sensor_TEST, AddSequence)
   EXPECT_EQ(1, header2.data_size());
   EXPECT_EQ(1, header2.data(0).value_size());
   EXPECT_EQ("0", header2.data(0).value(0));
+}
+
+//////////////////////////////////////////////////
+TEST(Sensor_TEST, Topic)
+{
+  TestSensor sensor;
+  EXPECT_EQ("", sensor.Topic());
+
+  EXPECT_TRUE(sensor.SetTopic("/topic"));
+  EXPECT_EQ("/topic", sensor.Topic());
+
+  EXPECT_TRUE(sensor.SetTopic("/topic with  spaces/@~characters//"));
+  EXPECT_EQ("/topic_with__spaces/characters", sensor.Topic());
+
+  EXPECT_FALSE(sensor.SetTopic(""));
 }
 
 //////////////////////////////////////////////////

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -107,8 +107,8 @@ TEST(Sensor_TEST, Topic)
   EXPECT_TRUE(sensor.SetTopic("/topic"));
   EXPECT_EQ("/topic", sensor.Topic());
 
-  EXPECT_TRUE(sensor.SetTopic("/topic with  spaces/@~characters//"));
-  EXPECT_EQ("/topic_with__spaces/characters", sensor.Topic());
+  EXPECT_TRUE(sensor.SetTopic("/topic with spaces/@~characters//"));
+  EXPECT_EQ("/topic_with_spaces/characters", sensor.Topic());
 
   EXPECT_FALSE(sensor.SetTopic(""));
 }

--- a/test/integration/air_pressure_plugin.cc
+++ b/test/integration/air_pressure_plugin.cc
@@ -254,7 +254,7 @@ TEST_F(AirPressureSensorTest, Topic)
 
   // Convert to valid topic
   {
-    const std::string topic = "/topic with  spaces/@~characters//";
+    const std::string topic = "/topic with spaces/@~characters//";
     auto airPressureSdf = AirPressureToSdf(name, sensorPose,
           updateRate, topic, alwaysOn, visualize);
 
@@ -265,7 +265,7 @@ TEST_F(AirPressureSensorTest, Topic)
         dynamic_cast<ignition::sensors::AirPressureSensor *>(sensor.release());
     ASSERT_NE(nullptr, airPressure);
 
-    EXPECT_EQ("/topic_with__spaces/characters", airPressure->Topic());
+    EXPECT_EQ("/topic_with_spaces/characters", airPressure->Topic());
   }
 
   // Invalid topic

--- a/test/integration/altimeter_plugin.cc
+++ b/test/integration/altimeter_plugin.cc
@@ -27,7 +27,7 @@
 #include "TransportTestTools.hh"
 
 /// \brief Helper function to create an altimeter sdf element
-sdf::ElementPtr AltimeterToSDF(const std::string &_name,
+sdf::ElementPtr AltimeterToSdf(const std::string &_name,
     const ignition::math::Pose3d &_pose, const double _updateRate,
     const std::string &_topic, const bool _alwaysOn,
     const bool _visualize)
@@ -124,7 +124,7 @@ TEST_F(AltimeterSensorTest, CreateAltimeter)
   // Create sensor SDF
   ignition::math::Pose3d sensorPose(ignition::math::Vector3d(0.25, 0.0, 0.5),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr altimeterSDF = AltimeterToSDF(name, sensorPose,
+  sdf::ElementPtr altimeterSdf = AltimeterToSdf(name, sensorPose,
         updateRate, topic, alwaysOn, visualize);
 
   sdf::ElementPtr altimeterSdfNoise = AltimeterToSdfWithNoise(name, sensorPose,
@@ -134,7 +134,7 @@ TEST_F(AltimeterSensorTest, CreateAltimeter)
   ignition::sensors::SensorFactory sf;
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::AltimeterSensor> sensor =
-      sf.CreateSensor<ignition::sensors::AltimeterSensor>(altimeterSDF);
+      sf.CreateSensor<ignition::sensors::AltimeterSensor>(altimeterSdf);
   EXPECT_TRUE(sensor != nullptr);
 
   EXPECT_EQ(name, sensor->Name());
@@ -164,7 +164,7 @@ TEST_F(AltimeterSensorTest, SensorReadings)
   // Create sensor SDF
   ignition::math::Pose3d sensorPose(ignition::math::Vector3d(0.25, 0.0, 0.5),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr altimeterSDF = AltimeterToSDF(name, sensorPose,
+  sdf::ElementPtr altimeterSdf = AltimeterToSdf(name, sensorPose,
         updateRate, topic, alwaysOn, visualize);
 
   sdf::ElementPtr altimeterSdfNoise = AltimeterToSdfWithNoise(name, sensorPose,
@@ -175,7 +175,7 @@ TEST_F(AltimeterSensorTest, SensorReadings)
   ignition::sensors::SensorFactory sf;
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::Sensor> s =
-      sf.CreateSensor(altimeterSDF);
+      sf.CreateSensor(altimeterSdf);
   std::unique_ptr<ignition::sensors::AltimeterSensor> sensor(
       dynamic_cast<ignition::sensors::AltimeterSensor *>(s.release()));
 
@@ -248,6 +248,63 @@ TEST_F(AltimeterSensorTest, SensorReadings)
   EXPECT_FALSE(ignition::math::equal(pos - vertRef,
         msgNoise.vertical_position()));
   EXPECT_FALSE(ignition::math::equal(vertVel, msgNoise.vertical_velocity()));
+}
+
+/////////////////////////////////////////////////
+TEST_F(AltimeterSensorTest, Topic)
+{
+  const std::string name = "TestAltimeter";
+  const double updateRate = 30;
+  const bool alwaysOn = 1;
+  const bool visualize = 1;
+  auto sensorPose = ignition::math::Pose3d();
+
+  // Factory
+  ignition::sensors::SensorFactory factory;
+  factory.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH,
+      "lib"));
+
+  // Default topic
+  {
+    const std::string topic;
+    auto altimeterSdf = AltimeterToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor(altimeterSdf);
+    EXPECT_NE(nullptr, sensor);
+
+    auto altimeter =
+        dynamic_cast<ignition::sensors::AltimeterSensor *>(sensor.release());
+    ASSERT_NE(nullptr, altimeter);
+
+    EXPECT_EQ("/altimeter", altimeter->Topic());
+  }
+
+  // Convert to valid topic
+  {
+    const std::string topic = "/topic with  spaces/@~characters//";
+    auto altimeterSdf = AltimeterToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor(altimeterSdf);
+    EXPECT_NE(nullptr, sensor);
+
+    auto altimeter =
+        dynamic_cast<ignition::sensors::AltimeterSensor *>(sensor.release());
+    ASSERT_NE(nullptr, altimeter);
+
+    EXPECT_EQ("/topic_with__spaces/characters", altimeter->Topic());
+  }
+
+  // Invalid topic
+  {
+    const std::string topic = "@@@";
+    auto altimeterSdf = AltimeterToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor(altimeterSdf);
+    ASSERT_EQ(nullptr, sensor);
+  }
 }
 
 int main(int argc, char **argv)

--- a/test/integration/altimeter_plugin.cc
+++ b/test/integration/altimeter_plugin.cc
@@ -282,7 +282,7 @@ TEST_F(AltimeterSensorTest, Topic)
 
   // Convert to valid topic
   {
-    const std::string topic = "/topic with  spaces/@~characters//";
+    const std::string topic = "/topic with spaces/@~characters//";
     auto altimeterSdf = AltimeterToSdf(name, sensorPose,
           updateRate, topic, alwaysOn, visualize);
 
@@ -293,7 +293,7 @@ TEST_F(AltimeterSensorTest, Topic)
         dynamic_cast<ignition::sensors::AltimeterSensor *>(sensor.release());
     ASSERT_NE(nullptr, altimeter);
 
-    EXPECT_EQ("/topic_with__spaces/characters", altimeter->Topic());
+    EXPECT_EQ("/topic_with_spaces/characters", altimeter->Topic());
   }
 
   // Invalid topic

--- a/test/integration/depth_camera_plugin.cc
+++ b/test/integration/depth_camera_plugin.cc
@@ -432,7 +432,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
       for (unsigned int j = 0; j < depthSensor->ImageWidth(); ++j)
       {
         float d = g_depthBuffer[step + j];
-        EXPECT_FLOAT_EQ(expectedDepth, d);
+        EXPECT_NEAR(expectedDepth, d, DOUBLE_TOL);
       }
     }
   }
@@ -445,7 +445,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
       for (unsigned int j = 0; j < depthSensor->ImageWidth(); ++j)
       {
         float x = g_pointsXYZBuffer[step + j*3];
-        EXPECT_FLOAT_EQ(expectedDepth, x);
+        EXPECT_NEAR(expectedDepth, x, DOUBLE_TOL);
       }
     }
 

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -790,7 +790,6 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
 void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
 {
   const std::string name = "TestGpuLidar";
-  const std::string parent = "parent_link";
   const double updateRate = 30;
   const unsigned int horzSamples = 640;
   const double horzResolution = 1;
@@ -845,7 +844,7 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
 
   // Convert to valid topic
   {
-    const std::string topic = "/topic with  spaces/@~characters//";
+    const std::string topic = "/topic with spaces/@~characters//";
     auto lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
       horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
@@ -860,7 +859,7 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
     auto lidar = dynamic_cast<ignition::sensors::GpuLidarSensor *>(sensor);
     ASSERT_NE(nullptr, lidar);
 
-    EXPECT_EQ("/topic_with__spaces/characters/points", lidar->Topic());
+    EXPECT_EQ("/topic_with_spaces/characters/points", lidar->Topic());
   }
 
   // Invalid topic

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -41,7 +41,7 @@
 #define VERTICAL_LASER_TOL 1e-3
 #define WAIT_TIME 0.02
 
-sdf::ElementPtr GpuLidarToSDF(const std::string &name,
+sdf::ElementPtr GpuLidarToSdf(const std::string &name,
     const ignition::math::Pose3d &pose, const double updateRate,
     const std::string &topic, const double horzSamples,
     const double horzResolution, const double horzMinAngle,
@@ -138,6 +138,9 @@ class GpuLidarSensorTest: public testing::Test,
 
   // Test manually updating sensors
   public: void ManualUpdate(const std::string &_renderEngine);
+
+  // Test topics
+  public: void Topic(const std::string &_renderEngine);
 };
 
 /////////////////////////////////////////////////
@@ -166,7 +169,7 @@ void GpuLidarSensorTest::CreateGpuLidar(const std::string &_renderEngine)
   // Create sensor description in SDF
   ignition::math::Pose3d testPose(ignition::math::Vector3d(0, 0, 0.1),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr lidarSDF = GpuLidarToSDF(name, testPose, updateRate, topic,
+  sdf::ElementPtr lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
     horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
     vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
     rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
@@ -192,7 +195,7 @@ void GpuLidarSensorTest::CreateGpuLidar(const std::string &_renderEngine)
 
   // Create a GpuLidarSensor
   ignition::sensors::GpuLidarSensor *sensor =
-      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSDF);
+      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf);
   sensor->SetParent(parent);
   // Make sure the above dynamic cast worked.
   EXPECT_TRUE(sensor != nullptr);
@@ -283,7 +286,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   // Create sensor SDF
   ignition::math::Pose3d testPose(ignition::math::Vector3d(0.0, 0.0, 0.1),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr lidarSDF = GpuLidarToSDF(name, testPose, updateRate, topic,
+  sdf::ElementPtr lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
     horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
     vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
     rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
@@ -319,7 +322,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
 
   // Create a GpuLidarSensor
   ignition::sensors::GpuLidarSensor *sensor =
-      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSDF);
+      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf);
   // Make sure the above dynamic cast worked.
   EXPECT_TRUE(sensor != nullptr);
   sensor->SetParent(parent);
@@ -429,7 +432,7 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   // Create sensor SDF
   ignition::math::Pose3d testPose1(ignition::math::Vector3d(0, 0, 0.1),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr lidarSDF1 = GpuLidarToSDF(name1, testPose1, updateRate,
+  sdf::ElementPtr lidarSdf1 = GpuLidarToSdf(name1, testPose1, updateRate,
       topic1, horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
       rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
@@ -437,7 +440,7 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   // Create a second sensor SDF rotated
   ignition::math::Pose3d testPose2(ignition::math::Vector3d(0, 0, 0.1),
       ignition::math::Quaterniond(IGN_PI/2.0, 0, 0));
-  sdf::ElementPtr lidarSDF2 = GpuLidarToSDF(name2, testPose2, updateRate,
+  sdf::ElementPtr lidarSdf2 = GpuLidarToSdf(name2, testPose2, updateRate,
       topic2, horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
       rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
@@ -463,11 +466,11 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
 
   // Create a GpuLidarSensors
   ignition::sensors::GpuLidarSensor *sensor1 =
-      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSDF1);
+      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf1);
 
   // Create second GpuLidarSensor
   ignition::sensors::GpuLidarSensor *sensor2 =
-      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSDF2);
+      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf2);
 
   // Make sure the above dynamic cast worked.
   EXPECT_TRUE(sensor1 != nullptr);
@@ -572,7 +575,7 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
   // Create sensor SDF
   ignition::math::Pose3d testPose(ignition::math::Vector3d(0.25, 0.0, 0.5),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr lidarSDF = GpuLidarToSDF(name, testPose, updateRate, topic,
+  sdf::ElementPtr lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
     horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
     vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
     rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
@@ -609,7 +612,7 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
 
   // Create a GpuLidarSensor
   ignition::sensors::GpuLidarSensor *sensor =
-      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSDF);
+      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf);
 
   // Make sure the above dynamic cast worked.
   EXPECT_TRUE(sensor != nullptr);
@@ -693,7 +696,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   // Create sensor SDF
   ignition::math::Pose3d testPose1(ignition::math::Vector3d(0, 0, 0.1),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr lidarSDF1 = GpuLidarToSDF(name1, testPose1, updateRate,
+  sdf::ElementPtr lidarSdf1 = GpuLidarToSdf(name1, testPose1, updateRate,
       topic1, horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
       rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
@@ -701,7 +704,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   // Create a second sensor SDF at an xy offset of 1
   ignition::math::Pose3d testPose2(ignition::math::Vector3d(1, 1, 0.1),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr lidarSDF2 = GpuLidarToSDF(name2, testPose2, updateRate,
+  sdf::ElementPtr lidarSdf2 = GpuLidarToSdf(name2, testPose2, updateRate,
       topic2, horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
       vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
       rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
@@ -727,11 +730,11 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
 
   // Create a GpuLidarSensors
   ignition::sensors::GpuLidarSensor *sensor1 =
-      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSDF1);
+      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf1);
 
   // Create second GpuLidarSensor
   ignition::sensors::GpuLidarSensor *sensor2 =
-      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSDF2);
+      mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf2);
 
   // Make sure the above dynamic cast worked.
   EXPECT_TRUE(sensor1 != nullptr);
@@ -783,6 +786,96 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   ignition::rendering::unloadEngine(engine->Name());
 }
 
+/////////////////////////////////////////////////
+void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
+{
+  const std::string name = "TestGpuLidar";
+  const std::string parent = "parent_link";
+  const double updateRate = 30;
+  const unsigned int horzSamples = 640;
+  const double horzResolution = 1;
+  const double horzMinAngle = -1.396263;
+  const double horzMaxAngle = 1.396263;
+  const double vertResolution = 1;
+  const unsigned int vertSamples = 1;
+  const double vertMinAngle = 0;
+  const double vertMaxAngle = 0;
+  const double rangeResolution = 0.01;
+  const double rangeMin = 0.08;
+  const double rangeMax = 10.0;
+  const bool alwaysOn = 1;
+  const bool visualize = 1;
+  auto testPose = ignition::math::Pose3d();
+
+  // Scene
+  auto engine = ignition::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+  auto scene = engine->CreateScene("scene");
+  EXPECT_NE(nullptr, scene);
+
+  // Create a GpuLidarSensor
+  ignition::sensors::Manager mgr;
+  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
+
+
+  // Default topic
+  {
+    const std::string topic;
+    auto lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
+      horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
+      vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+
+    auto sensorId = mgr.CreateSensor(lidarSdf);
+    EXPECT_NE(ignition::sensors::NO_SENSOR, sensorId);
+
+    auto sensor = mgr.Sensor(sensorId);
+    EXPECT_NE(nullptr, sensor);
+
+    auto lidar = dynamic_cast<ignition::sensors::GpuLidarSensor *>(sensor);
+    ASSERT_NE(nullptr, lidar);
+
+    EXPECT_EQ("/lidar/points", lidar->Topic());
+  }
+
+  // Convert to valid topic
+  {
+    const std::string topic = "/topic with  spaces/@~characters//";
+    auto lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
+      horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
+      vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+
+    auto sensorId = mgr.CreateSensor(lidarSdf);
+    EXPECT_NE(ignition::sensors::NO_SENSOR, sensorId);
+
+    auto sensor = mgr.Sensor(sensorId);
+    EXPECT_NE(nullptr, sensor);
+
+    auto lidar = dynamic_cast<ignition::sensors::GpuLidarSensor *>(sensor);
+    ASSERT_NE(nullptr, lidar);
+
+    EXPECT_EQ("/topic_with__spaces/characters/points", lidar->Topic());
+  }
+
+  // Invalid topic
+  {
+    const std::string topic = "@@@";
+    auto lidarSdf = GpuLidarToSdf(name, testPose, updateRate, topic,
+      horzSamples, horzResolution, horzMinAngle, horzMaxAngle,
+      vertSamples, vertResolution, vertMinAngle, vertMaxAngle,
+      rangeResolution, rangeMin, rangeMax, alwaysOn, visualize);
+
+    auto sensorId = mgr.CreateSensor(lidarSdf);
+    EXPECT_EQ(ignition::sensors::NO_SENSOR, sensorId);
+  }
+}
+
 TEST_P(GpuLidarSensorTest, CreateGpuLidar)
 {
   CreateGpuLidar(GetParam());
@@ -806,6 +899,11 @@ TEST_P(GpuLidarSensorTest, VerticalLidar)
 TEST_P(GpuLidarSensorTest, ManualUpdate)
 {
   ManualUpdate(GetParam());
+}
+
+TEST_P(GpuLidarSensorTest, Topic)
+{
+  Topic(GetParam());
 }
 
 INSTANTIATE_TEST_CASE_P(GpuLidarSensor, GpuLidarSensorTest,

--- a/test/integration/imu_plugin.cc
+++ b/test/integration/imu_plugin.cc
@@ -257,7 +257,7 @@ TEST_F(ImuSensorTest, Topic)
 
   // Convert to valid topic
   {
-    const std::string topic = "/topic with  spaces/@~characters//";
+    const std::string topic = "/topic with spaces/@~characters//";
     auto imuSdf = ImuToSdf(name, sensorPose,
           updateRate, topic, alwaysOn, visualize);
 
@@ -268,7 +268,7 @@ TEST_F(ImuSensorTest, Topic)
         dynamic_cast<ignition::sensors::ImuSensor *>(sensor.release());
     ASSERT_NE(nullptr, imu);
 
-    EXPECT_EQ("/topic_with__spaces/characters", imu->Topic());
+    EXPECT_EQ("/topic_with_spaces/characters", imu->Topic());
   }
 
   // Invalid topic

--- a/test/integration/imu_plugin.cc
+++ b/test/integration/imu_plugin.cc
@@ -26,7 +26,7 @@
 #include "TransportTestTools.hh"
 
 /// \brief Helper function to create an imu sdf element
-sdf::ElementPtr ImuToSDF(const std::string &_name,
+sdf::ElementPtr ImuToSdf(const std::string &_name,
     const ignition::math::Pose3d &_pose, const double _updateRate,
     const std::string &_topic, const bool _alwaysOn,
     const bool _visualize)
@@ -74,14 +74,14 @@ TEST_F(ImuSensorTest, CreateImu)
   // Create sensor SDF
   ignition::math::Pose3d sensorPose(ignition::math::Vector3d(0.25, 0.0, 0.5),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr imuSDF = ImuToSDF(name, sensorPose,
+  sdf::ElementPtr imuSdf = ImuToSdf(name, sensorPose,
         updateRate, topic, alwaysOn, visualize);
 
   // create the sensor using sensor factory
   ignition::sensors::SensorFactory sf;
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::ImuSensor> sensor =
-      sf.CreateSensor<ignition::sensors::ImuSensor>(imuSDF);
+      sf.CreateSensor<ignition::sensors::ImuSensor>(imuSdf);
   EXPECT_TRUE(sensor != nullptr);
 
   EXPECT_EQ(name, sensor->Name());
@@ -102,7 +102,7 @@ TEST_F(ImuSensorTest, SensorReadings)
   // Create sensor SDF
   ignition::math::Pose3d sensorPose(ignition::math::Vector3d(0.25, 0.0, 0.5),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr imuSDF = ImuToSDF(name, sensorPose,
+  sdf::ElementPtr imuSdf = ImuToSdf(name, sensorPose,
         updateRate, topic, alwaysOn, visualize);
 
   // create the sensor using sensor factory
@@ -110,7 +110,7 @@ TEST_F(ImuSensorTest, SensorReadings)
   ignition::sensors::SensorFactory sf;
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::Sensor> s =
-      sf.CreateSensor(imuSDF);
+      sf.CreateSensor(imuSdf);
   std::unique_ptr<ignition::sensors::ImuSensor> sensor(
       dynamic_cast<ignition::sensors::ImuSensor *>(s.release()));
 
@@ -224,6 +224,62 @@ TEST_F(ImuSensorTest, SensorReadings)
   EXPECT_EQ(
       ignition::math::Quaterniond(ignition::math::Vector3d(0, 3.14, -1.57)),
       ignition::msgs::Convert(msg.orientation()));
+}
+
+/////////////////////////////////////////////////
+TEST_F(ImuSensorTest, Topic)
+{
+  const std::string name = "TestImu";
+  const double updateRate = 30;
+  const bool alwaysOn = 1;
+  const bool visualize = 1;
+  auto sensorPose = ignition::math::Pose3d();
+
+  // Factory
+  ignition::sensors::SensorFactory factory;
+  factory.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH,
+      "lib"));
+
+  // Default topic
+  {
+    const std::string topic;
+    auto imuSdf = ImuToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor(imuSdf);
+    EXPECT_NE(nullptr, sensor);
+
+    auto imu = dynamic_cast<ignition::sensors::ImuSensor *>(sensor.release());
+    ASSERT_NE(nullptr, imu);
+
+    EXPECT_EQ("/imu", imu->Topic());
+  }
+
+  // Convert to valid topic
+  {
+    const std::string topic = "/topic with  spaces/@~characters//";
+    auto imuSdf = ImuToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor(imuSdf);
+    EXPECT_NE(nullptr, sensor);
+
+    auto imu =
+        dynamic_cast<ignition::sensors::ImuSensor *>(sensor.release());
+    ASSERT_NE(nullptr, imu);
+
+    EXPECT_EQ("/topic_with__spaces/characters", imu->Topic());
+  }
+
+  // Invalid topic
+  {
+    const std::string topic = "@@@";
+    auto imuSdf = ImuToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor(imuSdf);
+    ASSERT_EQ(nullptr, sensor);
+  }
 }
 
 int main(int argc, char **argv)

--- a/test/integration/logical_camera_plugin.cc
+++ b/test/integration/logical_camera_plugin.cc
@@ -259,7 +259,8 @@ TEST_F(LogicalCameraSensorTest, Topic)
     EXPECT_NE(nullptr, sensor);
 
     auto logicalCamera =
-        dynamic_cast<ignition::sensors::LogicalCameraSensor *>(sensor.release());
+        dynamic_cast<ignition::sensors::LogicalCameraSensor *>(
+        sensor.release());
     ASSERT_NE(nullptr, logicalCamera);
 
     EXPECT_EQ("/logical_camera", logicalCamera->Topic());
@@ -267,7 +268,7 @@ TEST_F(LogicalCameraSensorTest, Topic)
 
   // Convert to valid topic
   {
-    const std::string topic = "/topic with  spaces/@~characters//";
+    const std::string topic = "/topic with spaces/@~characters//";
     auto logicalCameraSdf = LogicalCameraToSdf(name, sensorPose,
         updateRate, topic, near, far, horzFov, aspectRatio, alwaysOn,
         visualize);
@@ -276,10 +277,11 @@ TEST_F(LogicalCameraSensorTest, Topic)
     EXPECT_NE(nullptr, sensor);
 
     auto logicalCamera =
-        dynamic_cast<ignition::sensors::LogicalCameraSensor *>(sensor.release());
+        dynamic_cast<ignition::sensors::LogicalCameraSensor *>(
+        sensor.release());
     ASSERT_NE(nullptr, logicalCamera);
 
-    EXPECT_EQ("/topic_with__spaces/characters", logicalCamera->Topic());
+    EXPECT_EQ("/topic_with_spaces/characters", logicalCamera->Topic());
   }
 
   // Invalid topic

--- a/test/integration/magnetometer_plugin.cc
+++ b/test/integration/magnetometer_plugin.cc
@@ -317,7 +317,7 @@ TEST_F(MagnetometerSensorTest, Topic)
 
   // Convert to valid topic
   {
-    const std::string topic = "/topic with  spaces/@~characters//";
+    const std::string topic = "/topic with spaces/@~characters//";
     auto magnetometerSdf = MagnetometerToSdf(name, sensorPose,
           updateRate, topic, alwaysOn, visualize);
 
@@ -328,7 +328,7 @@ TEST_F(MagnetometerSensorTest, Topic)
         dynamic_cast<ignition::sensors::MagnetometerSensor *>(sensor.release());
     ASSERT_NE(nullptr, magnetometer);
 
-    EXPECT_EQ("/topic_with__spaces/characters", magnetometer->Topic());
+    EXPECT_EQ("/topic_with_spaces/characters", magnetometer->Topic());
   }
 
   // Invalid topic

--- a/test/integration/magnetometer_plugin.cc
+++ b/test/integration/magnetometer_plugin.cc
@@ -26,7 +26,7 @@
 #include "TransportTestTools.hh"
 
 /// \brief Helper function to create an magnetometer sdf element
-sdf::ElementPtr MagnetometerToSDF(const std::string &_name,
+sdf::ElementPtr MagnetometerToSdf(const std::string &_name,
     const ignition::math::Pose3d &_pose, const double _updateRate,
     const std::string &_topic, const bool _alwaysOn,
     const bool _visualize)
@@ -131,7 +131,7 @@ TEST_F(MagnetometerSensorTest, CreateMagnetometer)
   // Create sensor SDF
   ignition::math::Pose3d sensorPose(ignition::math::Vector3d(0.25, 0.0, 0.5),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr magnetometerSDF = MagnetometerToSDF(name, sensorPose,
+  sdf::ElementPtr magnetometerSdf = MagnetometerToSdf(name, sensorPose,
         updateRate, topic, alwaysOn, visualize);
 
   sdf::ElementPtr magnetometerNoiseSdf = MagnetometerToSdfWithNoise(name,
@@ -141,7 +141,7 @@ TEST_F(MagnetometerSensorTest, CreateMagnetometer)
   ignition::sensors::SensorFactory sf;
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::MagnetometerSensor> sensor =
-      sf.CreateSensor<ignition::sensors::MagnetometerSensor>(magnetometerSDF);
+      sf.CreateSensor<ignition::sensors::MagnetometerSensor>(magnetometerSdf);
   EXPECT_TRUE(sensor != nullptr);
 
   std::unique_ptr<ignition::sensors::MagnetometerSensor> sensorNoise =
@@ -171,7 +171,7 @@ TEST_F(MagnetometerSensorTest, SensorReadings)
   // Create sensor SDF
   ignition::math::Pose3d sensorPose(ignition::math::Vector3d(0.25, 0.0, 0.5),
       ignition::math::Quaterniond::Identity);
-  sdf::ElementPtr magnetometerSDF = MagnetometerToSDF(name, sensorPose,
+  sdf::ElementPtr magnetometerSdf = MagnetometerToSdf(name, sensorPose,
         updateRate, topic, alwaysOn, visualize);
   sdf::ElementPtr magnetometerSdfNoise = MagnetometerToSdfWithNoise(name,
       sensorPose, updateRate, noiseTopic, alwaysOn, visualize, 1.0, 0.2, 10.0);
@@ -181,7 +181,7 @@ TEST_F(MagnetometerSensorTest, SensorReadings)
   ignition::sensors::SensorFactory sf;
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::Sensor> s =
-      sf.CreateSensor(magnetometerSDF);
+      sf.CreateSensor(magnetometerSdf);
   std::unique_ptr<ignition::sensors::MagnetometerSensor> sensor(
       dynamic_cast<ignition::sensors::MagnetometerSensor *>(s.release()));
 
@@ -283,6 +283,63 @@ TEST_F(MagnetometerSensorTest, SensorReadings)
   EXPECT_EQ(2, msg.header().stamp().sec());
   EXPECT_EQ(0, msg.header().stamp().nsec());
   EXPECT_EQ(localField, ignition::msgs::Convert(msg.field_tesla()));
+}
+
+/////////////////////////////////////////////////
+TEST_F(MagnetometerSensorTest, Topic)
+{
+  const std::string name = "TestMagnetometer";
+  const double updateRate = 30;
+  const bool alwaysOn = 1;
+  const bool visualize = 1;
+  auto sensorPose = ignition::math::Pose3d();
+
+  // Factory
+  ignition::sensors::SensorFactory factory;
+  factory.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH,
+      "lib"));
+
+  // Default topic
+  {
+    const std::string topic;
+    auto magnetometerSdf = MagnetometerToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor(magnetometerSdf);
+    EXPECT_NE(nullptr, sensor);
+
+    auto magnetometer =
+        dynamic_cast<ignition::sensors::MagnetometerSensor *>(sensor.release());
+    ASSERT_NE(nullptr, magnetometer);
+
+    EXPECT_EQ("/magnetometer", magnetometer->Topic());
+  }
+
+  // Convert to valid topic
+  {
+    const std::string topic = "/topic with  spaces/@~characters//";
+    auto magnetometerSdf = MagnetometerToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor(magnetometerSdf);
+    EXPECT_NE(nullptr, sensor);
+
+    auto magnetometer =
+        dynamic_cast<ignition::sensors::MagnetometerSensor *>(sensor.release());
+    ASSERT_NE(nullptr, magnetometer);
+
+    EXPECT_EQ("/topic_with__spaces/characters", magnetometer->Topic());
+  }
+
+  // Invalid topic
+  {
+    const std::string topic = "@@@";
+    auto magnetometerSdf = MagnetometerToSdf(name, sensorPose,
+          updateRate, topic, alwaysOn, visualize);
+
+    auto sensor = factory.CreateSensor(magnetometerSdf);
+    ASSERT_EQ(nullptr, sensor);
+  }
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Requires https://github.com/ignitionrobotics/ign-transport/pull/153/
Addresses https://github.com/ignitionrobotics/ign-gazebo/issues/239

* Make sure all sensors have a default topic
* When invalid topics are passed in, convert them to valid topics if possible
* If not possible to convert into valid topic, fail gracefully