### PR TITLE
Update camera sensor only when needed

### DIFF
--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -319,6 +319,12 @@ bool CameraSensor::Update(const ignition::common::Time &_now)
   // move the camera to the current pose
   this->dataPtr->camera->SetLocalPose(this->Pose());
 
+  // render only if necessary
+  if (!this->dataPtr->pub.HasConnections() &&
+      this->dataPtr->imageEvent.ConnectionCount() <= 0 &&
+      !this->dataPtr->saveImage)
+    return true;
+
   // generate sensor data
   this->Render();
   {
@@ -375,13 +381,16 @@ bool CameraSensor::Update(const ignition::common::Time &_now)
   }
 
   // Trigger callbacks.
-  try
+  if (this->dataPtr->imageEvent.ConnectionCount() > 0)
   {
-    this->dataPtr->imageEvent(msg);
-  }
-  catch(...)
-  {
-    ignerr << "Exception thrown in an image callback.\n";
+    try
+    {
+      this->dataPtr->imageEvent(msg);
+    }
+    catch(...)
+    {
+      ignerr << "Exception thrown in an image callback.\n";
+    }
   }
 
   // Save image

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -109,6 +109,9 @@ class ignition::sensors::CameraSensorPrivate
 
   /// \brief Baseline for stereo cameras.
   public: double baseline{0.0};
+
+  /// \brief Flag to indicate if sensor is generating data
+  public: bool generatingData = false;
 };
 
 //////////////////////////////////////////////////
@@ -323,7 +326,25 @@ bool CameraSensor::Update(const ignition::common::Time &_now)
   if (!this->dataPtr->pub.HasConnections() &&
       this->dataPtr->imageEvent.ConnectionCount() <= 0 &&
       !this->dataPtr->saveImage)
+  {
+    if (this->dataPtr->generatingData)
+    {
+      igndbg << "Disabling camera sensor: '" << this->Name() << "' data "
+             << "generation. " << std::endl;;
+      this->dataPtr->generatingData = false;
+    }
+
     return true;
+  }
+  else
+  {
+    if (!this->dataPtr->generatingData)
+    {
+      igndbg << "Enabling camera sensor: '" << this->Name() << "' data "
+             << "generation." << std::endl;;
+      this->dataPtr->generatingData = true;
+    }
+  }
 
   // generate sensor data
   this->Render();


### PR DESCRIPTION
Updated camera sensor to render and generate data only if there are subscribers or if it needs to save data to disk. This avoid unnecessary computation cost when the camera sensor is idle.


While testing I noticed that `this->dataPtr->pub.HasConnections()` reports correct value when I subscribe using `ign topic -e -t`. However, if I test with the `ImageDisplay` plugin in ign-gazebo, the `HasConnections` will always return true even after the plugin is closed. I verified that the ImageDisplay's destructor is called so maybe we're doing something wrong? cc @caguero 

Signed-off-by: Ian Chen <ichen@osrfoundation.org>