### PR TITLE
⬆️  Bump main to 5.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-sensors4 VERSION 4.0.0)
+project(ignition-sensors5 VERSION 5.0.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -13,7 +13,7 @@ find_package(ignition-cmake2 REQUIRED)
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project(VERSION_SUFFIX)
+ign_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/examples/imu_noise/CMakeLists.txt
+++ b/examples/imu_noise/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(ignition-sensors-noise-demo)
 
 # Find the Ignition Libraries used directly by the example
-find_package(ignition-sensors4 REQUIRED)
+find_package(ignition-sensors5 REQUIRED)
 
 add_executable(sensor_noise main.cc)
-target_link_libraries(sensor_noise PUBLIC ignition-sensors4)
+target_link_libraries(sensor_noise PUBLIC ignition-sensors5)

--- a/examples/save_image/CMakeLists.txt
+++ b/examples/save_image/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ignition-sensors-camera-demo)
 
 # Find the Ignition Libraries used directly by the example
 find_package(ignition-rendering4 REQUIRED OPTIONAL_COMPONENTS ogre ogre2)
-find_package(ignition-sensors4 REQUIRED COMPONENTS rendering camera)
+find_package(ignition-sensors5 REQUIRED COMPONENTS rendering camera)
 
 if (TARGET ignition-rendering4::ogre)
    add_definitions(-DWITH_OGRE)
@@ -14,4 +14,4 @@ endif()
 
 add_executable(save_image main.cc)
 target_link_libraries(save_image PUBLIC
-  ignition-sensors4::camera)
+  ignition-sensors5::camera)

--- a/tutorials/02_install.md
+++ b/tutorials/02_install.md
@@ -19,8 +19,8 @@ sudo apt-get update
 1. Install Ignition Sensors
 
 ```{.sh}
-# This installs ign-sensors4. Change the number after libignition-sensors to the version you want
-sudo apt install libignition-sensors4-dev
+# Change <#> to a version number, like 3 or 4
+sudo apt install libignition-sensors<#>-dev
 ```
 
 ## Source Install


### PR DESCRIPTION
The `ign-sensors4` branch was created off `main` for the Dome release.

Now bumping `main` to version 5 so it may receive breaking changes.