### PR TITLE
👩‍🌾 Prevent segfaults on test failures, make tests verbose

### DIFF
--- a/include/ignition/sensors/Manager.hh
+++ b/include/ignition/sensors/Manager.hh
@@ -123,13 +123,18 @@ namespace ignition
                 {
                   T *result = dynamic_cast<T*>(this->Sensor(id));
 
-                  if (!result)
-                    ignerr << "SDF sensor type does not match template type\n";
+                  if (nullptr == result)
+                  {
+                    ignerr << "Failed to create sensor [" << id << "] of type ["
+                           << _sdf->Get<std::string>("type")
+                           << "]. SDF sensor type does not match template type."
+                           << std::endl;
+                  }
 
                   return result;
                 }
 
-                ignerr << "Failed to create sensor of type["
+                ignerr << "Failed to create sensor of type ["
                        << _sdf->Get<std::string>("type") << "]\n";
                 return nullptr;
               }

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -123,6 +123,16 @@ sdf::ElementPtr CameraToSdf(const std::string &_type,
     ->GetElement("sensor");
 }
 
+/// \brief Test camera sensor
+class Camera_TEST : public ::testing::Test
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
+};
+
 //////////////////////////////////////////////////
 TEST(Camera_TEST, CreateCamera)
 {
@@ -136,7 +146,7 @@ TEST(Camera_TEST, CreateCamera)
     mgr.CreateSensor<ignition::sensors::CameraSensor>(camSdf);
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(cam != nullptr);
+  ASSERT_NE(nullptr, cam);
 
   // Check topics
   EXPECT_EQ("/cam", cam->Topic());

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -173,6 +173,15 @@ sdf::ElementPtr ImuSensorToSDF(const std::string &name, double update_rate,
     ->GetElement("sensor");
 }
 
+/// \brief Test IMU sensor
+class ImuSensor_TEST : public ::testing::Test
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
+};
 
 //////////////////////////////////////////////////
 TEST(ImuSensor_TEST, CreateImuSensor)
@@ -241,8 +250,8 @@ TEST(ImuSensor_TEST, ComputeNoise)
   auto sensor = mgr.CreateSensor<ignition::sensors::ImuSensor>(imuSDF);
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
-  EXPECT_TRUE(sensor_truth != nullptr);
+  ASSERT_NE(nullptr, sensor);
+  ASSERT_NE(nullptr, sensor_truth);
 
   sensor->SetAngularVelocity(math::Vector3d::Zero);
   sensor->SetLinearAcceleration(math::Vector3d::Zero);

--- a/src/Lidar_TEST.cc
+++ b/src/Lidar_TEST.cc
@@ -89,6 +89,16 @@ void OnNewLaserFrame(int *_scanCounter, float *_scanDest,
   *_scanCounter += 1;
 }
 
+/// \brief Test lidar sensor
+class Lidar_TEST : public ::testing::Test
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
+};
+
 /////////////////////////////////////////////////
 /// \brief Test Creation of a Lidar sensor
 TEST(Lidar_TEST, CreateLaser)
@@ -124,7 +134,7 @@ TEST(Lidar_TEST, CreateLaser)
       lidarSDF);
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   double angleRes = (sensor->AngleMax() - sensor->AngleMin()).Radian() /
                     sensor->RayCount();

--- a/src/Manager_TEST.cc
+++ b/src/Manager_TEST.cc
@@ -18,6 +18,15 @@
 #include <gtest/gtest.h>
 #include <ignition/sensors/Manager.hh>
 
+/// \brief Test sensor manager
+class Manager_TEST : public ::testing::Test
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
+};
 
 //////////////////////////////////////////////////
 TEST(Manager, construct)

--- a/src/Noise_TEST.cc
+++ b/src/Noise_TEST.cc
@@ -19,6 +19,7 @@
 
 #include <numeric>
 
+#include <ignition/common/Console.hh>
 #include <ignition/math/Rand.hh>
 
 #include "ignition/sensors/Noise.hh"
@@ -53,6 +54,16 @@ sdf::ElementPtr NoiseSdf(const std::string &_type, double _mean,
 
   return sdf;
 }
+
+/// \brief Test sensor noise
+class NoiseTest : public ::testing::Test
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
+};
 
 //////////////////////////////////////////////////
 // Test constructor

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -16,6 +16,7 @@
 */
 #include <gtest/gtest.h>
 
+#include <ignition/common/Console.hh>
 #include <ignition/sensors/Export.hh>
 #include <ignition/sensors/Sensor.hh>
 
@@ -31,6 +32,16 @@ class TestSensor : public Sensor
   }
 
   public: unsigned int updateCount{0};
+};
+
+/// \brief Test sensor class
+class Sensor_TEST : public ::testing::Test
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
 };
 
 //////////////////////////////////////////////////

--- a/test/integration/air_pressure_plugin.cc
+++ b/test/integration/air_pressure_plugin.cc
@@ -99,8 +99,14 @@ sdf::ElementPtr AirPressureToSdfWithNoise(const std::string &_name,
     ->GetElement("sensor");
 }
 
+/// \brief Test air pressure sensor
 class AirPressureSensorTest: public testing::Test
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
 };
 
 /////////////////////////////////////////////////
@@ -128,7 +134,7 @@ TEST_F(AirPressureSensorTest, CreateAirPressure)
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::AirPressureSensor> sensor =
       sf.CreateSensor<ignition::sensors::AirPressureSensor>(airPressureSdf);
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   EXPECT_EQ(name, sensor->Name());
   EXPECT_EQ(topic, sensor->Topic());
@@ -137,7 +143,7 @@ TEST_F(AirPressureSensorTest, CreateAirPressure)
   std::unique_ptr<ignition::sensors::AirPressureSensor> sensorNoise =
       sf.CreateSensor<ignition::sensors::AirPressureSensor>(
           airPressureSdfNoise);
-  EXPECT_TRUE(sensorNoise != nullptr);
+  ASSERT_NE(nullptr, sensorNoise);
 
   EXPECT_EQ(name, sensorNoise->Name());
   EXPECT_EQ(topicNoise, sensorNoise->Topic());
@@ -174,7 +180,7 @@ TEST_F(AirPressureSensorTest, SensorReadings)
       dynamic_cast<ignition::sensors::AirPressureSensor *>(s.release()));
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   std::unique_ptr<ignition::sensors::Sensor> sNoise =
       sf.CreateSensor(airPressureSdfNoise);
@@ -182,7 +188,7 @@ TEST_F(AirPressureSensorTest, SensorReadings)
       dynamic_cast<ignition::sensors::AirPressureSensor *>(sNoise.release()));
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensorNoise != nullptr);
+  ASSERT_NE(nullptr, sensorNoise);
 
   // verify initial readings
   EXPECT_DOUBLE_EQ(0.0, sensor->ReferenceAltitude());

--- a/test/integration/altimeter_plugin.cc
+++ b/test/integration/altimeter_plugin.cc
@@ -106,8 +106,14 @@ sdf::ElementPtr AltimeterToSdfWithNoise(const std::string &_name,
     ->GetElement("sensor");
 }
 
+/// \brief Test altimeter sensor
 class AltimeterSensorTest: public testing::Test
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
 };
 
 /////////////////////////////////////////////////
@@ -135,7 +141,7 @@ TEST_F(AltimeterSensorTest, CreateAltimeter)
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::AltimeterSensor> sensor =
       sf.CreateSensor<ignition::sensors::AltimeterSensor>(altimeterSdf);
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   EXPECT_EQ(name, sensor->Name());
   EXPECT_EQ(topic, sensor->Topic());
@@ -143,7 +149,7 @@ TEST_F(AltimeterSensorTest, CreateAltimeter)
 
   std::unique_ptr<ignition::sensors::AltimeterSensor> sensorNoise =
       sf.CreateSensor<ignition::sensors::AltimeterSensor>(altimeterSdfNoise);
-  EXPECT_TRUE(sensorNoise != nullptr);
+  ASSERT_NE(nullptr, sensorNoise);
 
   EXPECT_EQ(name, sensorNoise->Name());
   EXPECT_EQ(topicNoise, sensorNoise->Topic());
@@ -180,7 +186,7 @@ TEST_F(AltimeterSensorTest, SensorReadings)
       dynamic_cast<ignition::sensors::AltimeterSensor *>(s.release()));
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   std::unique_ptr<ignition::sensors::Sensor> sNoise =
       sf.CreateSensor(altimeterSdfNoise);
@@ -188,7 +194,7 @@ TEST_F(AltimeterSensorTest, SensorReadings)
       dynamic_cast<ignition::sensors::AltimeterSensor *>(sNoise.release()));
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensorNoise != nullptr);
+  ASSERT_NE(nullptr, sensorNoise);
 
   // verify initial readings
   EXPECT_DOUBLE_EQ(0.0, sensor->VerticalReference());

--- a/test/integration/camera_plugin.cc
+++ b/test/integration/camera_plugin.cc
@@ -88,6 +88,7 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   ignition::rendering::unloadEngine(engine->Name());
 }
 
+//////////////////////////////////////////////////
 TEST_P(CameraSensorTest, ImagesWithBuiltinSDF)
 {
   ImagesWithBuiltinSDF(GetParam());
@@ -99,6 +100,7 @@ INSTANTIATE_TEST_CASE_P(CameraSensor, CameraSensorTest,
 //////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
+  ignition::common::Console::SetVerbosity(4);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/integration/depth_camera_plugin.cc
+++ b/test/integration/depth_camera_plugin.cc
@@ -477,6 +477,7 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
   ignition::rendering::unloadEngine(engine->Name());
 }
 
+//////////////////////////////////////////////////
 TEST_P(DepthCameraSensorTest, ImagesWithBuiltinSDF)
 {
   ImagesWithBuiltinSDF(GetParam());
@@ -488,6 +489,7 @@ INSTANTIATE_TEST_CASE_P(DepthCameraSensor, DepthCameraSensorTest,
 //////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
+  ignition::common::Console::SetVerbosity(4);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -198,7 +198,7 @@ void GpuLidarSensorTest::CreateGpuLidar(const std::string &_renderEngine)
       mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf);
   sensor->SetParent(parent);
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
   sensor->SetScene(scene);
 
   // Set a callback on the lidar sensor to get a scan
@@ -324,7 +324,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   ignition::sensors::GpuLidarSensor *sensor =
       mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf);
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
   sensor->SetParent(parent);
   sensor->SetScene(scene);
 
@@ -473,8 +473,8 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
       mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf2);
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor1 != nullptr);
-  EXPECT_TRUE(sensor2 != nullptr);
+  ASSERT_NE(nullptr, sensor1);
+  ASSERT_NE(nullptr, sensor2);
   sensor1->SetScene(scene);
   sensor2->SetScene(scene);
 
@@ -615,7 +615,7 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
       mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf);
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
   sensor->SetScene(scene);
 
   // Update sensor
@@ -737,8 +737,8 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
       mgr.CreateSensor<ignition::sensors::GpuLidarSensor>(lidarSdf2);
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor1 != nullptr);
-  EXPECT_TRUE(sensor2 != nullptr);
+  ASSERT_NE(nullptr, sensor1);
+  ASSERT_NE(nullptr, sensor2);
   sensor1->SetScene(scene);
   sensor2->SetScene(scene);
 
@@ -875,31 +875,37 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
   }
 }
 
+/////////////////////////////////////////////////
 TEST_P(GpuLidarSensorTest, CreateGpuLidar)
 {
   CreateGpuLidar(GetParam());
 }
 
+/////////////////////////////////////////////////
 TEST_P(GpuLidarSensorTest, DetectBox)
 {
   DetectBox(GetParam());
 }
 
+/////////////////////////////////////////////////
 TEST_P(GpuLidarSensorTest, TestThreeBoxes)
 {
   TestThreeBoxes(GetParam());
 }
 
+/////////////////////////////////////////////////
 TEST_P(GpuLidarSensorTest, VerticalLidar)
 {
   VerticalLidar(GetParam());
 }
 
+/////////////////////////////////////////////////
 TEST_P(GpuLidarSensorTest, ManualUpdate)
 {
   ManualUpdate(GetParam());
 }
 
+/////////////////////////////////////////////////
 TEST_P(GpuLidarSensorTest, Topic)
 {
   Topic(GetParam());
@@ -910,6 +916,7 @@ INSTANTIATE_TEST_CASE_P(GpuLidarSensor, GpuLidarSensorTest,
 
 int main(int argc, char **argv)
 {
+  ignition::common::Console::SetVerbosity(4);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/integration/imu_plugin.cc
+++ b/test/integration/imu_plugin.cc
@@ -57,8 +57,14 @@ sdf::ElementPtr ImuToSdf(const std::string &_name,
     ->GetElement("sensor");
 }
 
+/// \brief Test IMU sensor
 class ImuSensorTest: public testing::Test
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
 };
 
 /////////////////////////////////////////////////
@@ -82,7 +88,7 @@ TEST_F(ImuSensorTest, CreateImu)
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::ImuSensor> sensor =
       sf.CreateSensor<ignition::sensors::ImuSensor>(imuSdf);
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   EXPECT_EQ(name, sensor->Name());
   EXPECT_EQ(topic, sensor->Topic());
@@ -115,7 +121,7 @@ TEST_F(ImuSensorTest, SensorReadings)
       dynamic_cast<ignition::sensors::ImuSensor *>(s.release()));
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   // subscribe to the topic
   WaitForMessageTestHelper<ignition::msgs::IMU> msgHelper(topic);

--- a/test/integration/logical_camera_plugin.cc
+++ b/test/integration/logical_camera_plugin.cc
@@ -78,8 +78,14 @@ sdf::ElementPtr LogicalCameraToSdf(const std::string &_name,
     ->GetElement("sensor");
 }
 
+/// \brief Test logical camera sensor
 class LogicalCameraSensorTest: public testing::Test
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
 };
 
 /////////////////////////////////////////////////
@@ -108,7 +114,7 @@ TEST_F(LogicalCameraSensorTest, CreateLogicalCamera)
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::LogicalCameraSensor> sensor =
       sf.CreateSensor<ignition::sensors::LogicalCameraSensor>(logicalCameraSdf);
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   EXPECT_EQ(name, sensor->Name());
   EXPECT_EQ(topic, sensor->Topic());
@@ -151,7 +157,7 @@ TEST_F(LogicalCameraSensorTest, DetectBox)
       dynamic_cast<ignition::sensors::LogicalCameraSensor *>(s.release()));
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   // verify initial image
   auto img = sensor->Image();

--- a/test/integration/magnetometer_plugin.cc
+++ b/test/integration/magnetometer_plugin.cc
@@ -112,9 +112,14 @@ sdf::ElementPtr MagnetometerToSdfWithNoise(const std::string &_name,
     ->GetElement("sensor");
 }
 
-
+/// \brief Test magnetometer sensor
 class MagnetometerSensorTest: public testing::Test
 {
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
 };
 
 /////////////////////////////////////////////////
@@ -142,12 +147,12 @@ TEST_F(MagnetometerSensorTest, CreateMagnetometer)
   sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::MagnetometerSensor> sensor =
       sf.CreateSensor<ignition::sensors::MagnetometerSensor>(magnetometerSdf);
-  EXPECT_TRUE(sensor != nullptr);
+  ASSERT_NE(nullptr, sensor);
 
   std::unique_ptr<ignition::sensors::MagnetometerSensor> sensorNoise =
     sf.CreateSensor<ignition::sensors::MagnetometerSensor>(
         magnetometerNoiseSdf);
-  EXPECT_TRUE(sensorNoise != nullptr);
+  ASSERT_NE(nullptr, sensorNoise);
 
   EXPECT_EQ(name, sensor->Name());
   EXPECT_EQ(name, sensorNoise->Name());
@@ -191,8 +196,8 @@ TEST_F(MagnetometerSensorTest, SensorReadings)
       dynamic_cast<ignition::sensors::MagnetometerSensor *>(sNoise.release()));
 
   // Make sure the above dynamic cast worked.
-  EXPECT_TRUE(sensor != nullptr);
-  EXPECT_TRUE(sensorNoise != nullptr);
+  ASSERT_NE(nullptr, sensor);
+  ASSERT_NE(nullptr, sensorNoise);
 
   // subscribe to the topic
   WaitForMessageTestHelper<ignition::msgs::Magnetometer> msgHelper(topic);

--- a/test/integration/rgbd_camera_plugin.cc
+++ b/test/integration/rgbd_camera_plugin.cc
@@ -714,6 +714,7 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
   ignition::rendering::unloadEngine(engine->Name());
 }
 
+//////////////////////////////////////////////////
 TEST_P(RgbdCameraSensorTest, ImagesWithBuiltinSDF)
 {
   ImagesWithBuiltinSDF(GetParam());
@@ -725,6 +726,7 @@ INSTANTIATE_TEST_CASE_P(RgbdCameraSensor, RgbdCameraSensorTest,
 //////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
+  ignition::common::Console::SetVerbosity(4);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/integration/thermal_camera_plugin.cc
+++ b/test/integration/thermal_camera_plugin.cc
@@ -315,6 +315,7 @@ void ThermalCameraSensorTest::ImagesWithBuiltinSDF(
   ignition::rendering::unloadEngine(engine->Name());
 }
 
+//////////////////////////////////////////////////
 TEST_P(ThermalCameraSensorTest, ImagesWithBuiltinSDF)
 {
   ImagesWithBuiltinSDF(GetParam());
@@ -326,6 +327,7 @@ INSTANTIATE_TEST_CASE_P(ThermalCameraSensor, ThermalCameraSensorTest,
 //////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
+  ignition::common::Console::SetVerbosity(4);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This should help shed some light into #4 .

* Use `ASSERT_NE(nullptr...)` to prevent test segfaults
* Make all tests verbose to help debug issues

It looks like the sensor is created correctly, but the problem happens when casting the sensor to the desired type. Maybe there's a mismatch between the types from the core library and the sensor's shared library? I vaguely remember @ahcorde having a solution for this while working on #38, but I don't know if that solution works for Citadel.

CC @scpeters , who was looking into #4.