### PR TITLE
👩‍🌾 Suggestions on addressing Windows warnings

### DIFF
--- a/examples/save_image/main.cc
+++ b/examples/save_image/main.cc
@@ -24,7 +24,22 @@
 #include <ignition/common/Image.hh>
 #include <ignition/common/Console.hh>
 #include <ignition/math/Helpers.hh>
-#include <ignition/rendering.hh>
+
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/Material.hh>
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
+#include <ignition/rendering/Visual.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include <ignition/sensors.hh>
 
 void OnImageFrame(const ignition::msgs::Image &_image)

--- a/examples/save_image/main.cc
+++ b/examples/save_image/main.cc
@@ -36,7 +36,7 @@
 #include <ignition/rendering/RenderingIface.hh>
 #include <ignition/rendering/Scene.hh>
 #include <ignition/rendering/Visual.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/CameraSensor.hh
+++ b/include/ignition/sensors/CameraSensor.hh
@@ -27,13 +27,13 @@
 #include <ignition/common/SuppressWarning.hh>
 #include <ignition/common/Time.hh>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 
@@ -44,7 +44,7 @@
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/rendering/Camera.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/CameraSensor.hh
+++ b/include/ignition/sensors/CameraSensor.hh
@@ -30,13 +30,23 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
 #include <ignition/rendering/Camera.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "ignition/sensors/camera/Export.hh"
 #include "ignition/sensors/config.hh"

--- a/include/ignition/sensors/DepthCameraSensor.hh
+++ b/include/ignition/sensors/DepthCameraSensor.hh
@@ -28,13 +28,13 @@
 #include <ignition/common/SuppressWarning.hh>
 #include <ignition/common/Time.hh>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 
@@ -45,7 +45,7 @@
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/rendering/DepthCamera.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/DepthCameraSensor.hh
+++ b/include/ignition/sensors/DepthCameraSensor.hh
@@ -24,20 +24,30 @@
 #include <sdf/sdf.hh>
 
 #include <ignition/common/Event.hh>
-
 #include <ignition/common/PluginMacros.hh>
+#include <ignition/common/SuppressWarning.hh>
 #include <ignition/common/Time.hh>
 
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
 #include <ignition/rendering/DepthCamera.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "ignition/sensors/depth_camera/Export.hh"
 #include "ignition/sensors/CameraSensor.hh"
@@ -165,9 +175,11 @@ namespace ignition
       private: void OnSceneChange(ignition::rendering::ScenePtr /*_scene*/)
               { }
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal
       private: std::unique_ptr<DepthCameraSensorPrivate> dataPtr;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }
   }

--- a/include/ignition/sensors/GpuLidarSensor.hh
+++ b/include/ignition/sensors/GpuLidarSensor.hh
@@ -24,7 +24,16 @@
 
 #include <ignition/common/SuppressWarning.hh>
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
 #include <ignition/rendering/GpuRays.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "ignition/sensors/gpu_lidar/Export.hh"
 #include "ignition/sensors/RenderingEvents.hh"

--- a/include/ignition/sensors/GpuLidarSensor.hh
+++ b/include/ignition/sensors/GpuLidarSensor.hh
@@ -31,7 +31,7 @@
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/rendering/GpuRays.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/ImageGaussianNoiseModel.hh
+++ b/include/ignition/sensors/ImageGaussianNoiseModel.hh
@@ -27,7 +27,7 @@
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/rendering/Camera.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/ImageGaussianNoiseModel.hh
+++ b/include/ignition/sensors/ImageGaussianNoiseModel.hh
@@ -20,7 +20,16 @@
 
 #include <sdf/sdf.hh>
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
 #include <ignition/rendering/Camera.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "ignition/sensors/config.hh"
 #include "ignition/sensors/GaussianNoiseModel.hh"

--- a/include/ignition/sensors/LogicalCameraSensor.hh
+++ b/include/ignition/sensors/LogicalCameraSensor.hh
@@ -32,6 +32,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
 #ifdef _MSC_VER

--- a/include/ignition/sensors/LogicalCameraSensor.hh
+++ b/include/ignition/sensors/LogicalCameraSensor.hh
@@ -29,13 +29,13 @@
 
 #include <ignition/math/Angle.hh>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/RenderingEvents.hh
+++ b/include/ignition/sensors/RenderingEvents.hh
@@ -20,7 +20,18 @@
 
 #include <ignition/common/Event.hh>
 #include <ignition/common/SuppressWarning.hh>
-#include <ignition/rendering/Scene.hh>
+
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/RenderTypes.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include <ignition/sensors/config.hh>
 #include <ignition/sensors/rendering/Export.hh>
 
@@ -47,6 +58,7 @@ namespace ignition
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Event that is used to trigger callbacks when the scene
       /// is changed
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       public: static ignition::common::EventT<
               void(const ignition::rendering::ScenePtr &)> sceneEvent;
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING

--- a/include/ignition/sensors/RenderingEvents.hh
+++ b/include/ignition/sensors/RenderingEvents.hh
@@ -58,7 +58,6 @@ namespace ignition
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Event that is used to trigger callbacks when the scene
       /// is changed
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       public: static ignition::common::EventT<
               void(const ignition::rendering::ScenePtr &)> sceneEvent;
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING

--- a/include/ignition/sensors/RenderingEvents.hh
+++ b/include/ignition/sensors/RenderingEvents.hh
@@ -28,7 +28,7 @@
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/rendering/RenderTypes.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/RenderingSensor.hh
+++ b/include/ignition/sensors/RenderingSensor.hh
@@ -27,8 +27,7 @@
 #pragma warning(push)
 #pragma warning(disable: 4251)
 #endif
-#include <ignition/rendering/Scene.hh>
-#include <ignition/rendering/Sensor.hh>
+#include <ignition/rendering/RenderTypes.hh>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/include/ignition/sensors/RenderingSensor.hh
+++ b/include/ignition/sensors/RenderingSensor.hh
@@ -28,7 +28,7 @@
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/rendering/RenderTypes.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/RenderingSensor.hh
+++ b/include/ignition/sensors/RenderingSensor.hh
@@ -21,8 +21,17 @@
 
 #include <ignition/common/SuppressWarning.hh>
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
 #include <ignition/rendering/Scene.hh>
 #include <ignition/rendering/Sensor.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "ignition/sensors/rendering/Export.hh"
 #include "ignition/sensors/Sensor.hh"

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -20,6 +20,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/header.pb.h>
 #ifdef _MSC_VER

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -17,13 +17,13 @@
 #ifndef IGNITION_SENSORS_SENSOR_HH_
 #define IGNITION_SENSORS_SENSOR_HH_
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/header.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/ThermalCameraSensor.hh
+++ b/include/ignition/sensors/ThermalCameraSensor.hh
@@ -28,13 +28,13 @@
 #include <ignition/common/SuppressWarning.hh>
 #include <ignition/common/Time.hh>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 
@@ -45,7 +45,7 @@
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/rendering/ThermalCamera.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/include/ignition/sensors/ThermalCameraSensor.hh
+++ b/include/ignition/sensors/ThermalCameraSensor.hh
@@ -31,13 +31,23 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
 #include <ignition/rendering/ThermalCamera.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "ignition/sensors/thermal_camera/Export.hh"
 #include "ignition/sensors/CameraSensor.hh"

--- a/src/AirPressureSensor.cc
+++ b/src/AirPressureSensor.cc
@@ -18,6 +18,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/fluid_pressure.pb.h>
 #ifdef _MSC_VER

--- a/src/AirPressureSensor.cc
+++ b/src/AirPressureSensor.cc
@@ -15,13 +15,13 @@
  *
 */
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/fluid_pressure.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/AltimeterSensor.cc
+++ b/src/AltimeterSensor.cc
@@ -18,10 +18,10 @@
 #include <ignition/common/Profiler.hh>
 #include <ignition/transport/Node.hh>
 
-#include "ignition/sensors/Noise.hh"
-#include "ignition/sensors/SensorTypes.hh"
-#include "ignition/sensors/SensorFactory.hh"
 #include "ignition/sensors/AltimeterSensor.hh"
+#include "ignition/sensors/Noise.hh"
+#include "ignition/sensors/SensorFactory.hh"
+#include "ignition/sensors/SensorTypes.hh"
 
 using namespace ignition;
 using namespace sensors;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,36 +44,6 @@ target_link_libraries(${rendering_target}
     ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
 )
 
-if (MSVC)
-  # Warning #4251 is the "dll-interface" warning that tells you when types used
-  # by a class are not being exported. These generated source files have private
-  # members that don't get exported, so they trigger this warning. However, the
-  # warning is not important since those members do not need to be interfaced
-  # with.
-  set_source_files_properties(
-      ${gtest_sources}
-      ${rendering_sources}
-      ${sources}
-      AirPressureSensor.cc
-      AltimeterSensor.cc
-      Camera.cc
-      CameraSensor.cc
-      Camera_TEST.cc
-      DepthCameraSensor.cc
-      GpuLidarSensor.cc
-      ImuSensor.cc
-      ImuSensor_TEST.cc
-      Lidar.cc
-      Lidar_TEST.cc
-      LogicalCameraSensor.cc
-      MagnetometerSensor.cc
-      RgbdCameraSensor.cc
-      ThermalCameraSensor.cc
-    COMPILE_FLAGS "/wd4251 /wd4146"
-  )
-endif()
-
-
 set(camera_sources CameraSensor.cc)
 ign_add_component(camera SOURCES ${camera_sources} GET_TARGET_NAME camera_target)
 # custom compile definitions since the one provided automatically is versioned and will

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -14,13 +14,13 @@
  * limitations under the License.
  *
 */
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/camera_info.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -17,6 +17,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/camera_info.pb.h>
 #ifdef _MSC_VER
@@ -31,9 +32,8 @@
 #include <ignition/common/Profiler.hh>
 #include <ignition/common/StringUtils.hh>
 #include <ignition/math/Angle.hh>
-#include <ignition/transport/Node.hh>
-
 #include <ignition/math/Helpers.hh>
+#include <ignition/transport/Node.hh>
 
 #include "ignition/sensors/CameraSensor.hh"
 #include "ignition/sensors/ImageGaussianNoiseModel.hh"

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -14,13 +14,13 @@
  * limitations under the License.
  *
 */
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/pointcloud_packed.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -17,6 +17,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/pointcloud_packed.pb.h>
 #ifdef _MSC_VER

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -15,13 +15,13 @@
  *
 */
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/pointcloud_packed.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -18,16 +18,18 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/pointcloud_packed.pb.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-#include <ignition/msgs/Utility.hh>
-#include <ignition/transport/Node.hh>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
+#include <ignition/msgs/Utility.hh>
+#include <ignition/transport/Node.hh>
+
 #include "ignition/sensors/GpuLidarSensor.hh"
 #include "ignition/sensors/SensorFactory.hh"
 

--- a/src/ImageGaussianNoiseModel.cc
+++ b/src/ImageGaussianNoiseModel.cc
@@ -32,7 +32,7 @@
 #include <ignition/rendering/RenderPass.hh>
 #include <ignition/rendering/RenderEngine.hh>
 #include <ignition/rendering/RenderPassSystem.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/ImageGaussianNoiseModel.cc
+++ b/src/ImageGaussianNoiseModel.cc
@@ -20,13 +20,23 @@
   #include <Winsock2.h>
 #endif
 
-#include "ignition/common/Console.hh"
-#include "ignition/sensors/ImageGaussianNoiseModel.hh"
-#include "ignition/rendering/GaussianNoisePass.hh"
-#include "ignition/rendering/RenderPass.hh"
-#include "ignition/rendering/RenderEngine.hh"
-#include "ignition/rendering/RenderPassSystem.hh"
+#include <ignition/common/Console.hh>
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/GaussianNoisePass.hh>
+#include <ignition/rendering/RenderPass.hh>
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderPassSystem.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#include "ignition/sensors/ImageGaussianNoiseModel.hh"
 
 using namespace ignition;
 using namespace sensors;

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -17,6 +17,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/imu.pb.h>
 #ifdef _MSC_VER
@@ -26,10 +27,10 @@
 #include <ignition/common/Profiler.hh>
 #include <ignition/transport/Node.hh>
 
+#include "ignition/sensors/ImuSensor.hh"
 #include "ignition/sensors/Noise.hh"
 #include "ignition/sensors/SensorFactory.hh"
 #include "ignition/sensors/SensorTypes.hh"
-#include "ignition/sensors/ImuSensor.hh"
 
 using namespace ignition;
 using namespace sensors;

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -14,13 +14,13 @@
  * limitations under the License.
  *
 */
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/imu.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -21,14 +21,15 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
-#include <ignition/sensors/ImuSensor.hh>
 #include <ignition/sensors/Export.hh>
+#include <ignition/sensors/ImuSensor.hh>
 #include <ignition/sensors/Manager.hh>
 
 using namespace ignition;

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -18,13 +18,13 @@
 #include <sdf/sdf.hh>
 
 #include <ignition/math/Helpers.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -20,11 +20,11 @@
 #include <ignition/transport/Node.hh>
 #include <sdf/Lidar.hh>
 
+#include "ignition/sensors/GaussianNoiseModel.hh"
 #include "ignition/sensors/Lidar.hh"
 #include "ignition/sensors/Noise.hh"
 #include "ignition/sensors/SensorFactory.hh"
 #include "ignition/sensors/SensorTypes.hh"
-#include "ignition/sensors/GaussianNoiseModel.hh"
 
 using namespace ignition::sensors;
 

--- a/src/Lidar_TEST.cc
+++ b/src/Lidar_TEST.cc
@@ -22,6 +22,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
 #ifdef _MSC_VER

--- a/src/Lidar_TEST.cc
+++ b/src/Lidar_TEST.cc
@@ -19,13 +19,13 @@
 
 #include <ignition/math/Angle.hh>
 #include <ignition/math/Helpers.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/MagnetometerSensor.cc
+++ b/src/MagnetometerSensor.cc
@@ -18,6 +18,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/magnetometer.pb.h>
 #ifdef _MSC_VER
@@ -28,10 +29,10 @@
 #include <ignition/transport/Node.hh>
 #include <sdf/Magnetometer.hh>
 
+#include "ignition/sensors/MagnetometerSensor.hh"
 #include "ignition/sensors/Noise.hh"
 #include "ignition/sensors/SensorFactory.hh"
 #include "ignition/sensors/SensorTypes.hh"
-#include "ignition/sensors/MagnetometerSensor.hh"
 
 using namespace ignition;
 using namespace sensors;

--- a/src/MagnetometerSensor.cc
+++ b/src/MagnetometerSensor.cc
@@ -15,13 +15,13 @@
  *
 */
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/magnetometer.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/Noise.cc
+++ b/src/Noise.cc
@@ -25,8 +25,8 @@
 
 #include <ignition/common/Console.hh>
 
-#include <ignition/sensors/GaussianNoiseModel.hh>
-#include <ignition/sensors/Noise.hh>
+#include "ignition/sensors/GaussianNoiseModel.hh"
+#include "ignition/sensors/Noise.hh"
 
 using namespace ignition;
 using namespace sensors;

--- a/src/Noise.cc
+++ b/src/Noise.cc
@@ -23,9 +23,10 @@
 
 #include <functional>
 
-#include <ignition/sensors/Noise.hh>
 #include <ignition/common/Console.hh>
+
 #include <ignition/sensors/GaussianNoiseModel.hh>
+#include <ignition/sensors/Noise.hh>
 
 using namespace ignition;
 using namespace sensors;

--- a/src/PointCloudUtil.hh
+++ b/src/PointCloudUtil.hh
@@ -21,6 +21,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/pointcloud_packed.pb.h>
 #ifdef _MSC_VER

--- a/src/PointCloudUtil.hh
+++ b/src/PointCloudUtil.hh
@@ -18,13 +18,13 @@
 #ifndef IGNITION_SENSORS_POINTCLOUDUTIL_HH_
 #define IGNITION_SENSORS_POINTCLOUDUTIL_HH_
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/pointcloud_packed.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 #include <ignition/math/Angle.hh>

--- a/src/RenderingSensor.cc
+++ b/src/RenderingSensor.cc
@@ -17,7 +17,16 @@
 
 #include <ignition/common/Profiler.hh>
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
 #include <ignition/rendering/Camera.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "ignition/sensors/RenderingSensor.hh"
 

--- a/src/RenderingSensor.cc
+++ b/src/RenderingSensor.cc
@@ -24,7 +24,7 @@
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/rendering/Camera.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -15,14 +15,14 @@
  *
 */
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/image.pb.h>
 #include <ignition/msgs/pointcloud_packed.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 
@@ -38,7 +38,7 @@
 #endif
 #include <ignition/rendering/Camera.hh>
 #include <ignition/rendering/DepthCamera.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -18,6 +18,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/image.pb.h>
 #include <ignition/msgs/pointcloud_packed.pb.h>
@@ -29,8 +30,18 @@
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/Helpers.hh>
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
 #include <ignition/rendering/Camera.hh>
 #include <ignition/rendering/DepthCamera.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include <ignition/transport/Node.hh>
 
 #include <sdf/Sensor.hh>

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -18,10 +18,11 @@
 #include "ignition/sensors/Sensor.hh"
 #include <map>
 #include <vector>
-#include <ignition/sensors/Manager.hh>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
 #include <ignition/transport/TopicUtils.hh>
+
+#include <ignition/sensors/Manager.hh>
 
 using namespace ignition::sensors;
 

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -15,13 +15,13 @@
  *
 */
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/image.pb.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -18,6 +18,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/image.pb.h>
 #ifdef _MSC_VER

--- a/test/integration/camera_plugin.cc
+++ b/test/integration/camera_plugin.cc
@@ -30,17 +30,17 @@
 #include <ignition/rendering/RenderEngine.hh>
 #include <ignition/rendering/RenderingIface.hh>
 #include <ignition/rendering/Scene.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/test/integration/camera_plugin.cc
+++ b/test/integration/camera_plugin.cc
@@ -20,10 +20,24 @@
 #include <ignition/common/Filesystem.hh>
 #include <ignition/sensors/Manager.hh>
 #include <ignition/sensors/CameraSensor.hh>
-#include <ignition/rendering.hh>
+
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
 #ifdef _MSC_VER

--- a/test/integration/depth_camera_plugin.cc
+++ b/test/integration/depth_camera_plugin.cc
@@ -17,14 +17,14 @@
 
 #include <gtest/gtest.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/camera_info.pb.h>
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 
@@ -44,7 +44,7 @@
 #include <ignition/rendering/RenderingIface.hh>
 #include <ignition/rendering/Scene.hh>
 #include <ignition/rendering/Visual.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/test/integration/depth_camera_plugin.cc
+++ b/test/integration/depth_camera_plugin.cc
@@ -20,6 +20,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/camera_info.pb.h>
 #include <ignition/msgs.hh>
@@ -31,7 +32,21 @@
 #include <ignition/common/Event.hh>
 #include <ignition/sensors/Manager.hh>
 #include <ignition/sensors/DepthCameraSensor.hh>
-#include <ignition/rendering.hh>
+
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/Material.hh>
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
+#include <ignition/rendering/Visual.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -26,13 +26,13 @@
 #include <ignition/sensors/GpuLidarSensor.hh>
 #include <ignition/math/Angle.hh>
 #include <ignition/math/Helpers.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 #include <ignition/transport/Node.hh>
@@ -47,7 +47,7 @@
 #include <ignition/rendering/RenderingIface.hh>
 #include <ignition/rendering/Scene.hh>
 #include <ignition/rendering/Visual.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -29,13 +29,28 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 #include <ignition/transport/Node.hh>
-#include <ignition/rendering.hh>
+
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
+#include <ignition/rendering/Visual.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include <sdf/sdf.hh>
 
 #include "test_config.h"  // NOLINT(build/include)

--- a/test/integration/logical_camera_plugin.cc
+++ b/test/integration/logical_camera_plugin.cc
@@ -27,13 +27,13 @@
 #include <ignition/sensors/Export.hh>
 
 #include <ignition/math/Helpers.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 #include <ignition/transport/Node.hh>

--- a/test/integration/logical_camera_plugin.cc
+++ b/test/integration/logical_camera_plugin.cc
@@ -30,6 +30,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs.hh>
 #ifdef _MSC_VER

--- a/test/integration/rgbd_camera_plugin.cc
+++ b/test/integration/rgbd_camera_plugin.cc
@@ -17,14 +17,14 @@
 
 #include <gtest/gtest.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/camera_info.pb.h>
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 
@@ -44,7 +44,7 @@
 #include <ignition/rendering/RenderingIface.hh>
 #include <ignition/rendering/Scene.hh>
 #include <ignition/rendering/Visual.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 

--- a/test/integration/rgbd_camera_plugin.cc
+++ b/test/integration/rgbd_camera_plugin.cc
@@ -20,6 +20,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/camera_info.pb.h>
 #include <ignition/msgs.hh>
@@ -31,7 +32,21 @@
 #include <ignition/common/Event.hh>
 #include <ignition/sensors/Manager.hh>
 #include <ignition/sensors/RgbdCameraSensor.hh>
-#include <ignition/rendering.hh>
+
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/Material.hh>
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
+#include <ignition/rendering/Visual.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"

--- a/test/integration/thermal_camera_plugin.cc
+++ b/test/integration/thermal_camera_plugin.cc
@@ -20,6 +20,7 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/camera_info.pb.h>
 #include <ignition/msgs.hh>
@@ -31,12 +32,23 @@
 #include <ignition/common/Event.hh>
 #include <ignition/sensors/Manager.hh>
 #include <ignition/sensors/ThermalCameraSensor.hh>
-#include <ignition/rendering.hh>
 
+// TODO(louise) Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
+#include <ignition/rendering/Visual.hh>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "test_config.h"  // NOLINT(build/include)
 #include "TransportTestTools.hh"
-
 
 #define DOUBLE_TOL 1e-6
 

--- a/test/integration/thermal_camera_plugin.cc
+++ b/test/integration/thermal_camera_plugin.cc
@@ -17,14 +17,14 @@
 
 #include <gtest/gtest.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4005)
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/msgs/camera_info.pb.h>
 #include <ignition/msgs.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 
@@ -43,7 +43,7 @@
 #include <ignition/rendering/RenderingIface.hh>
 #include <ignition/rendering/Scene.hh>
 #include <ignition/rendering/Visual.hh>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #pragma warning(pop)
 #endif
 


### PR DESCRIPTION
@ahcorde opened #58 as I was working on the same thing :sweat_smile: 

I started from the fixes in #38, but also made some additional changes to make sure we're only suppressing what we need to.

I was also targeting Citadel, but I rebased on top of #58 so we can get that one in, and we can backport everything afterwards.

The main updates here are:

* Remove the blanket warning suppression in favor of more localized suppression. This way, we can be sure we're not unknowingly introducing warnings of the same type.
* Treated `ign-rendering`'s warnings the same way as in https://github.com/ignitionrobotics/ign-gui/pull/112, with a note to remove the suppression here once they're fixed upstream.
* Broke apart `#include <ignition/rendering.hh>` to include only what we use (and reduce warnings in the process)
