### PR TITLE
Fix macOS/windows tests that failed to load library

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,39 @@
+name: macOS latest
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    env:
+      PACKAGE: ignition-sensors4
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - run: brew config
+
+    # Needed for X11Requirement
+    - run: brew cask install xquartz
+    - name: Install base dependencies
+      run: |
+        brew tap osrf/simulation;
+        brew install --only-dependencies ${PACKAGE};
+
+    - run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/${PACKAGE}/HEAD
+    - run: make
+      working-directory: build
+    - run: make test
+      working-directory: build
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+    - name: make install
+      working-directory: build
+      run: |
+        make install;
+        brew link ${PACKAGE};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,3 +136,19 @@ ign_build_tests(TYPE UNIT SOURCES ${gtest_sources} LIB_DEPS ${rendering_target})
 ign_build_tests(TYPE UNIT SOURCES Lidar_TEST.cc LIB_DEPS ${lidar_target})
 ign_build_tests(TYPE UNIT SOURCES Camera_TEST.cc LIB_DEPS ${camera_target})
 ign_build_tests(TYPE UNIT SOURCES ImuSensor_TEST.cc LIB_DEPS ${imu_target})
+
+set(plugin_test_targets)
+list(APPEND plugin_test_targets "UNIT_Camera_TEST")
+list(APPEND plugin_test_targets "UNIT_Lidar_TEST")
+list(APPEND plugin_test_targets "UNIT_ImuSensor_TEST")
+
+foreach(plugin_test ${plugin_test_targets})
+  if(TARGET ${plugin_test})
+    set(_env_vars)
+    list(APPEND _env_vars "IGN_PLUGIN_PATH=$<TARGET_FILE_DIR:${camera_target}>")
+    list(APPEND _env_vars "DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+
+    set_tests_properties(${plugin_test} PROPERTIES
+      ENVIRONMENT "${_env_vars}")
+  endif()
+endforeach()

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -53,3 +53,15 @@ ign_build_tests(TYPE INTEGRATION
     ${PROJECT_LIBRARY_TARGET_NAME}-imu
 )
 
+foreach(plugin_test ${dri_tests} ${tests})
+  get_filename_component(BINARY_NAME ${plugin_test} NAME_WE)
+  set(BINARY_NAME "${TEST_TYPE}_${BINARY_NAME}")
+  if(TARGET ${BINARY_NAME})
+    set(_env_vars)
+    list(APPEND _env_vars "IGN_PLUGIN_PATH=$<TARGET_FILE_DIR:${PROJECT_LIBRARY_TARGET_NAME}>")
+    list(APPEND _env_vars "DYLD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+
+    set_tests_properties(${BINARY_NAME} PROPERTIES
+      ENVIRONMENT "${_env_vars}")
+  endif()
+endforeach()

--- a/test/integration/air_pressure_plugin.cc
+++ b/test/integration/air_pressure_plugin.cc
@@ -125,7 +125,6 @@ TEST_F(AirPressureSensorTest, CreateAirPressure)
 
   // create the sensor using sensor factory
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::AirPressureSensor> sensor =
       sf.CreateSensor<ignition::sensors::AirPressureSensor>(airPressureSdf);
   EXPECT_TRUE(sensor != nullptr);
@@ -167,7 +166,6 @@ TEST_F(AirPressureSensorTest, SensorReadings)
   // create the sensor using sensor factory
   // try creating without specifying the sensor type and then cast it
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::Sensor> s =
       sf.CreateSensor(airPressureSdf);
   std::unique_ptr<ignition::sensors::AirPressureSensor> sensor(
@@ -234,8 +232,6 @@ TEST_F(AirPressureSensorTest, Topic)
 
   // Factory
   ignition::sensors::SensorFactory factory;
-  factory.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH,
-      "lib"));
 
   // Default topic
   {

--- a/test/integration/altimeter_plugin.cc
+++ b/test/integration/altimeter_plugin.cc
@@ -132,7 +132,6 @@ TEST_F(AltimeterSensorTest, CreateAltimeter)
 
   // create the sensor using sensor factory
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::AltimeterSensor> sensor =
       sf.CreateSensor<ignition::sensors::AltimeterSensor>(altimeterSdf);
   EXPECT_TRUE(sensor != nullptr);
@@ -173,7 +172,6 @@ TEST_F(AltimeterSensorTest, SensorReadings)
   // create the sensor using sensor factory
   // try creating without specifying the sensor type and then cast it
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::Sensor> s =
       sf.CreateSensor(altimeterSdf);
   std::unique_ptr<ignition::sensors::AltimeterSensor> sensor(
@@ -262,8 +260,6 @@ TEST_F(AltimeterSensorTest, Topic)
 
   // Factory
   ignition::sensors::SensorFactory factory;
-  factory.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH,
-      "lib"));
 
   // Default topic
   {

--- a/test/integration/camera_plugin.cc
+++ b/test/integration/camera_plugin.cc
@@ -63,7 +63,6 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
 
   // do the test
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
   ignition::sensors::CameraSensor *sensor =
       mgr.CreateSensor<ignition::sensors::CameraSensor>(sensorPtr);

--- a/test/integration/depth_camera_plugin.cc
+++ b/test/integration/depth_camera_plugin.cc
@@ -203,7 +203,6 @@ void DepthCameraSensorTest::ImagesWithBuiltinSDF(
 
   // do the test
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
   ignition::sensors::DepthCameraSensor *depthSensor =
       mgr.CreateSensor<ignition::sensors::DepthCameraSensor>(sensorPtr);

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -188,7 +188,6 @@ void GpuLidarSensorTest::CreateGpuLidar(const std::string &_renderEngine)
 
   // Create a sensor manager
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
   // Create an scene with a box in it
   scene->SetAmbientLight(0.3, 0.3, 0.3);
@@ -318,7 +317,6 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
 
   // Create a sensor manager
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
   // Create a GpuLidarSensor
   ignition::sensors::GpuLidarSensor *sensor =
@@ -463,7 +461,6 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
 
   // Create a sensor manager
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
   // Create a GpuLidarSensors
   ignition::sensors::GpuLidarSensor *sensor1 =
@@ -609,7 +606,6 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
 
   // Create a sensor manager
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
   // Create a GpuLidarSensor
   ignition::sensors::GpuLidarSensor *sensor =
@@ -727,7 +723,6 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
 
   // Create a sensor manager
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
   // Create a GpuLidarSensors
   ignition::sensors::GpuLidarSensor *sensor1 =
@@ -820,7 +815,6 @@ void GpuLidarSensorTest::Topic(const std::string &_renderEngine)
 
   // Create a GpuLidarSensor
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
 
   // Default topic

--- a/test/integration/imu_plugin.cc
+++ b/test/integration/imu_plugin.cc
@@ -79,7 +79,6 @@ TEST_F(ImuSensorTest, CreateImu)
 
   // create the sensor using sensor factory
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::ImuSensor> sensor =
       sf.CreateSensor<ignition::sensors::ImuSensor>(imuSdf);
   EXPECT_TRUE(sensor != nullptr);
@@ -108,7 +107,6 @@ TEST_F(ImuSensorTest, SensorReadings)
   // create the sensor using sensor factory
   // try creating without specifying the sensor type and then cast it
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::Sensor> s =
       sf.CreateSensor(imuSdf);
   std::unique_ptr<ignition::sensors::ImuSensor> sensor(
@@ -239,8 +237,6 @@ TEST_F(ImuSensorTest, Topic)
 
   // Factory
   ignition::sensors::SensorFactory factory;
-  factory.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH,
-      "lib"));
 
   // Default topic
   {

--- a/test/integration/logical_camera_plugin.cc
+++ b/test/integration/logical_camera_plugin.cc
@@ -105,7 +105,6 @@ TEST_F(LogicalCameraSensorTest, CreateLogicalCamera)
 
   // create the sensor using sensor factory
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::LogicalCameraSensor> sensor =
       sf.CreateSensor<ignition::sensors::LogicalCameraSensor>(logicalCameraSdf);
   EXPECT_TRUE(sensor != nullptr);
@@ -144,7 +143,6 @@ TEST_F(LogicalCameraSensorTest, DetectBox)
   // create the sensor using sensor factory
   // try creating without specifying the sensor type and then cast it
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::Sensor> s =
       sf.CreateSensor(logicalCameraSdf);
   std::unique_ptr<ignition::sensors::LogicalCameraSensor> sensor(
@@ -245,8 +243,6 @@ TEST_F(LogicalCameraSensorTest, Topic)
 
   // Factory
   ignition::sensors::SensorFactory factory;
-  factory.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH,
-      "lib"));
 
   // Default topic
   {

--- a/test/integration/magnetometer_plugin.cc
+++ b/test/integration/magnetometer_plugin.cc
@@ -139,7 +139,6 @@ TEST_F(MagnetometerSensorTest, CreateMagnetometer)
 
   // create the sensor using sensor factory
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::MagnetometerSensor> sensor =
       sf.CreateSensor<ignition::sensors::MagnetometerSensor>(magnetometerSdf);
   EXPECT_TRUE(sensor != nullptr);
@@ -179,7 +178,6 @@ TEST_F(MagnetometerSensorTest, SensorReadings)
   // create the sensor using sensor factory
   // try creating without specifying the sensor type and then cast it
   ignition::sensors::SensorFactory sf;
-  sf.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
   std::unique_ptr<ignition::sensors::Sensor> s =
       sf.CreateSensor(magnetometerSdf);
   std::unique_ptr<ignition::sensors::MagnetometerSensor> sensor(
@@ -299,8 +297,6 @@ TEST_F(MagnetometerSensorTest, Topic)
 
   // Factory
   ignition::sensors::SensorFactory factory;
-  factory.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH,
-      "lib"));
 
   // Default topic
   {

--- a/test/integration/rgbd_camera_plugin.cc
+++ b/test/integration/rgbd_camera_plugin.cc
@@ -223,7 +223,6 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
 
   // do the test
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
   ignition::sensors::RgbdCameraSensor *rgbdSensor =
       mgr.CreateSensor<ignition::sensors::RgbdCameraSensor>(sensorPtr);

--- a/test/integration/thermal_camera_plugin.cc
+++ b/test/integration/thermal_camera_plugin.cc
@@ -136,7 +136,6 @@ void ThermalCameraSensorTest::ImagesWithBuiltinSDF(
   root->AddChild(box);
 
   ignition::sensors::Manager mgr;
-  mgr.AddPluginPaths(ignition::common::joinPaths(PROJECT_BUILD_PATH, "lib"));
 
   ignition::sensors::ThermalCameraSensor *thermalSensor =
       mgr.CreateSensor<ignition::sensors::ThermalCameraSensor>(sensorPtr);


### PR DESCRIPTION
This adds a GitHub actions workflow that uses macOS Catalina to help debug the `UNIT_Lidar_TEST` failures reported in #4. It turns out that all the windows test failures and most on macOS are caused by a failure to load sensor component libraries properly and can be fixed by properly setting environment variables for the tests.

In windows CI and the macOS workflow (which runs `make test` before `make install`) tests were failing with the message "Unable to find sensor plugin path". This is fixed by setting the `IGN_PLUGIN_PATH` in cmake to the build folder containing the compiled plugins.

In the macOS jenkins build (which runs `make test` after `make install`) tests were failing with the message "SDF sensor type does not match template type". It was difficult to track down, but it appears to be caused by a failure to properly dlopen all the shared libraries linked by the component plugins when a test finds an installed component library, rather than one from the build folder. It is fixed by setting `DYLD_LIBRARY_PATH` to include the location of the installed libraries.

There were also some `AddPluginPaths` calls in integration tests that didn't work on all platforms and are now redundant after setting the environment variables in cmake, so I've removed those lines from the tests.