### PR TITLE
Avoid moving a return value, it might prevent (N)RVO

### DIFF
--- a/src/SensorFactory.cc
+++ b/src/SensorFactory.cc
@@ -137,7 +137,7 @@ std::unique_ptr<Sensor> SensorFactory::CreateSensor(const sdf::Sensor &_sdf)
   }
 
   result.reset(sensor);
-  return std::move(result);
+  return result;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Similar to https://github.com/ignitionrobotics/ign-math/pull/183.

---

I'm building in Focal, this PR fixes some "-Wno-pessimizing-move" warnings (which does not happen with the gcc version in Bionic).

From [here](https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/C_002b_002b-Dialect-Options.html):

```
-Wno-pessimizing-move (C++ and Objective-C++ only)
This warning warns when a call to std::move prevents copy elision. A typical scenario when copy elision can occur is when returning in a function with a class return type, when the expression being returned is the name of a non-volatile automatic object, and is not a function parameter, and has the same type as the function return type.

struct T {
…
};
T fn()
{
  T t;
  …
  return std::move (t);
}
But in this example, the std::move call prevents copy elision.

This warning is enabled by -Wall.
```