### PR TITLE
Add Windows installation

### DIFF
--- a/tutorials/02_install.md
+++ b/tutorials/02_install.md
@@ -99,7 +99,7 @@ conda install libignition-cmake<#> libignition-common<#> libignition-math<#> lib
 
 Before [ign-rendering](https://github.com/ignitionrobotics/ign-rendering) becomes available on conda-forge, follow its tutorial to build it from source.
 
-#### Building from source
+#### Build from source
 
 1. Activate the Conda environment created in the prerequisites:
 

--- a/tutorials/02_install.md
+++ b/tutorials/02_install.md
@@ -10,7 +10,7 @@ The source install instructions should be used if you need the very latest softw
 
 1. Setup your computer to accept software from packages.osrfoundation.org:
 
-```{.sh}
+```
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt-get update
@@ -18,10 +18,14 @@ sudo apt-get update
 
 1. Install Ignition Sensors
 
-```{.sh}
+```
 # This installs ign-sensors4. Change the number after libignition-sensors to the version you want
 sudo apt install libignition-sensors4-dev
 ```
+
+### Windows
+
+Binary install is pending ``ignition-rendering`` and ``ignition-sensors`` being added to conda-forge.
 
 ## Source Install
 
@@ -41,35 +45,92 @@ Ignition Sensors requires:
   * [SDFormat](https://github.com/osrf/sdformat)
   * [Protobuf3](https://developers.google.com/protocol-buffers/)
 
-### Building from source
+### Ubuntu
 
 1. Make sure you are running [Ubuntu Bionic](http://releases.ubuntu.com/18.04/) or above.
 
-2. Install the [Prerequisites](#prerequisites).
+2. Install the Prerequisites.
 
 3. Configure to use gcc8 if that is not the default compiler
 
-```{.sh}
+```
 sudo apt-get install g++-8
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 ```
 
 4. Clone the repository
 
-```{.sh}
+```
 git clone https://github.com/ignitionrobotics/ign-sensors
 ```
 
 5. Configure and build
 
-```{.sh}
+```
 cd ign-sensors; mkdir build; cd build; cmake ..;  make
 ```
 
 6. Optionally, install the library
 
-```{.sh}
+```
 sudo make install
 ```
 
+### Windows
 
+#### Install Prerequisites
+
+First, follow the [ign-cmake](https://github.com/ignitionrobotics/ign-cmake) tutorial for installing Conda, Visual Studio, CMake, etc., prerequisites, and creating a Conda environment.
+
+Navigate to ``condabin`` if necessary to use the ``conda`` command (i.e., if Conda is not in your `PATH` environment variable. You can find the location of ``condabin`` in Anaconda Prompt, ``where conda``).
+
+Create if necessary, and activate a Conda environment:
+
+```
+conda create -n ign-ws
+conda activate ign-ws
+```
+
+Install Ignition dependencies, replacing `<#>` with the desired versions:
+
+```
+conda install libignition-cmake<#> libignition-common<#> libignition-math<#> libignition-transport<#> libignition-msgs<#> libignition-plugin<#> --channel conda-forge
+```
+
+Before [ign-rendering](https://github.com/ignitionrobotics/ign-rendering) becomes available on conda-forge, follow its tutorial to build it from source.
+
+#### Building from source
+
+1. Activate the Conda environment created in the prerequisites:
+
+    ```
+    conda activate ign-ws
+    ```
+
+1. Navigate to where you would like to build the library, and clone the repository.
+
+    ```
+    # Optionally, append `-b ign-sensors#` (replace # with a number) to check out a specific version
+    git clone https://github.com/ignitionrobotics/ign-sensors.git
+    ```
+
+1. Configure and build
+
+    ```
+    cd ign-sensors
+    mkdir build
+    cd build
+    ```
+
+    Before ``ign-rendering`` becomes available on conda-forge, we need to build it from source and specify the path containing ``ignition-rendering-config.cmake`` in ``CMAKE_PREFIX_PATH``, for cmake to find ``ign-rendering``. That path could be ``ign-rendering-install-path\lib\cmake\ignition-rendering4``, for example.
+
+    ```
+    cmake .. -DBUILD_TESTING=OFF -DCMAKE_PREFIX_PATH=path\containing\ignition-rendering-config  # Optionally, -DCMAKE_INSTALL_PREFIX=path\to\install
+    cmake --build . --config Release
+    ```
+
+1. Optionally, install
+
+    ```
+    cmake --install . --config Release
+    ```


### PR DESCRIPTION
Partially addresses https://github.com/ignitionrobotics/docs/issues/117

Made headings and code blocks consistent with other per-package installation tutorials.

One of the dependencies, `libignition-rendering`, is not yet on conda-forge and needs to be installed from source.
`libignition-sensors` is also not on conda-forge, so we don't have binary install instructions for Windows in this PR.
Both libraries need to be added to conda-forge.