### PR TITLE
Apply noise to lidar point cloud

### DIFF
--- a/include/ignition/sensors/Lidar.hh
+++ b/include/ignition/sensors/Lidar.hh
@@ -58,6 +58,11 @@ namespace ignition
       /// \return true if the update was successfull
       public: virtual bool Update(const common::Time &_now) override;
 
+      /// \brief Apply noise to the laser buffer, if noise has been
+      /// configured. This should be called before PublishLidarScan if you
+      /// want the scan data to contain noise.
+      public: void ApplyNoise();
+
       /// \brief Publish LaserScan message
       /// \param[in] _now The current time
       /// \return true if the update was successfull

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -197,9 +197,9 @@ void Lidar::ApplyNoise()
 {
   if (this->dataPtr->noises.find(LIDAR_NOISE) != this->dataPtr->noises.end())
   {
-    for (unsigned int j = 0; j < this->VerticalRangeCount(); ++j)
+    for (unsigned int j = 0; j < this->VerticalRayCount(); ++j)
     {
-      for (unsigned int i = 0; i < this->RangeCount(); ++i)
+      for (unsigned int i = 0; i < this->RayCount(); ++i)
       {
         int index = j * this->RangeCount() + i;
         double range = this->laserBuffer[index*3];

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -193,6 +193,26 @@ bool Lidar::Update(const ignition::common::Time &/*_now*/)
 }
 
 //////////////////////////////////////////////////
+void Lidar::ApplyNoise()
+{
+  if (this->dataPtr->noises.find(LIDAR_NOISE) != this->dataPtr->noises.end())
+  {
+    for (unsigned int j = 0; j < this->VerticalRangeCount(); ++j)
+    {
+      for (unsigned int i = 0; i < this->RangeCount(); ++i)
+      {
+        int index = j * this->RangeCount() + i;
+        double range = this->laserBuffer[index*3];
+        range = this->dataPtr->noises[LIDAR_NOISE]->Apply(range);
+        range = ignition::math::clamp(range,
+            this->RangeMin(), this->RangeMax());
+        this->laserBuffer[index*3] = range;
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
 bool Lidar::PublishLidarScan(const ignition::common::Time &_now)
 {
   IGN_PROFILE("Lidar::PublishLidarScan");
@@ -235,14 +255,6 @@ bool Lidar::PublishLidarScan(const ignition::common::Time &_now)
     {
       int index = j * this->RangeCount() + i;
       double range = this->laserBuffer[index*3];
-
-      if (this->dataPtr->noises.find(LIDAR_NOISE) !=
-          this->dataPtr->noises.end())
-      {
-        range = this->dataPtr->noises[LIDAR_NOISE]->Apply(range);
-        range = ignition::math::clamp(range,
-            this->RangeMin(), this->RangeMax());
-      }
 
       range = ignition::math::isnan(range) ? this->RangeMax() : range;
       this->dataPtr->laserMsg.set_ranges(index, range);

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -201,7 +201,7 @@ void Lidar::ApplyNoise()
     {
       for (unsigned int i = 0; i < this->RayCount(); ++i)
       {
-        int index = j * this->RangeCount() + i;
+        int index = j * this->RayCount() + i;
         double range = this->laserBuffer[index*3];
         range = this->dataPtr->noises[LIDAR_NOISE]->Apply(range);
         range = ignition::math::clamp(range,


### PR DESCRIPTION
Noise was not applied to the point cloud generated by the GpuLidarSensor. This change applies noise to the `laserBuffer`, which then used by both the `scan` and `point cloud` topics.

Signed-off-by: Nate Koenig <nate@openrobotics.org>