### PR TITLE
Fix thermal camera info topic

### DIFF
--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -214,7 +214,7 @@ bool ThermalCameraSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
-  if (!this->AdvertiseInfo())
+  if (!this->AdvertiseInfo(this->Topic() + "/camera_info"))
     return false;
 
   if (this->Scene())


### PR DESCRIPTION
If no topic is specified in ign-gazebo for a thermal camera, currently the `camera_info` topic that's generated is missing the thermal camera sensor name. As example, before this change:

```
/world/thermal_camera/model/thermal_camera/link/link/sensor/camera_info
```

With the proposed changes:

```
/world/thermal_camera/model/thermal_camera/link/link/sensor/thermal_camera/camera_info
```

This PR uses the same approach as [done here in RGBDCameraSensor](https://github.com/ignitionrobotics/ign-sensors/blob/ign-sensors4/src/RgbdCameraSensor.cc#L236) for generating the camera_info topic.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>