### PR TITLE
Add set_rate service to all sensors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
     sdformat${SDF_VER}::sdformat${SDF_VER}
   PRIVATE
     ignition-common${IGN_COMMON_VER}::profiler
+    ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER}
 )
 target_compile_definitions(${PROJECT_LIBRARY_TARGET_NAME} PUBLIC DepthPoints_EXPORTS)
 

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -20,6 +20,8 @@
 #include <vector>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
+#include <ignition/msgs/double.pb.h>
+#include <ignition/transport/Node.hh>
 #include <ignition/transport/TopicUtils.hh>
 
 #include <ignition/sensors/Manager.hh>
@@ -36,6 +38,14 @@ class ignition::sensors::SensorPrivate
   /// \param[in] _topic Topic sensor publishes data to.
   /// \return True if a valid topic was set.
   public: bool SetTopic(const std::string &_topic);
+
+  /// \brief Set the rate on which the sensor should publish its data. This
+  /// method doesn't allow to set a higher rate than what is in the SDF.
+  /// \param[in] _rate Maximum rate of the sensor. It is capped by the
+  /// <update_rate> value from SDF, and zero is allowed only when zero is also
+  /// in SDF.
+  /// \return True if a valid topic was set.
+  public: void SetRate(const ignition::msgs::Double& _rate);
 
   /// \brief id given to sensor when constructed
   public: SensorId id;
@@ -55,8 +65,16 @@ class ignition::sensors::SensorPrivate
   /// \brief Pose of the sensor
   public: ignition::math::Pose3d pose;
 
-  /// \brief How many times the sensor will generate data per second
+  /// \brief How many times the sensor will generate data per second (value from
+  /// SDF.
+  public: double sdfUpdateRate = 0.0;
+
+  /// \brief How many times the sensor will generate data per second (currently
+  /// used value).
   public: double updateRate = 0.0;
+
+  /// \brief node to create rate update service server
+  public: transport::Node node;
 
   /// \brief What sim time should this sensor update at
   public: std::chrono::steady_clock::duration nextUpdateTime
@@ -110,7 +128,7 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
     this->pose = _sdf.RawPose();
   }
 
-  this->updateRate = _sdf.UpdateRate();
+  this->sdfUpdateRate = this->updateRate = _sdf.UpdateRate();
   return true;
 }
 
@@ -135,7 +153,25 @@ Sensor::~Sensor()
 //////////////////////////////////////////////////
 bool Sensor::Load(const sdf::Sensor &_sdf)
 {
-  return this->dataPtr->PopulateFromSDF(_sdf);
+  const bool success = this->dataPtr->PopulateFromSDF(_sdf);
+  if (!success)
+    return false;
+
+  auto sensorTopic = this->Topic();
+  if (sensorTopic.empty())
+    sensorTopic = "/" + this->Name();
+
+  const auto rateTopic = sensorTopic + "/set_rate";
+
+  if (!this->dataPtr->node.Advertise(rateTopic,
+    &SensorPrivate::SetRate, this->dataPtr.get()))
+  {
+    ignerr << "Unable to create service server on topic["
+           << rateTopic << "].\n";
+    return false;
+  }
+
+  return true;
 }
 
 //////////////////////////////////////////////////
@@ -150,7 +186,7 @@ bool Sensor::Load(sdf::ElementPtr _sdf)
 
   sdf::Sensor sdfSensor;
   sdfSensor.Load(_sdf);
-  return this->dataPtr->PopulateFromSDF(sdfSensor);
+  return this->Load(sdfSensor);
 }
 
 //////////////////////////////////////////////////
@@ -195,6 +231,42 @@ bool SensorPrivate::SetTopic(const std::string &_topic)
 
   this->topic = validTopic;
   return true;
+}
+
+//////////////////////////////////////////////////
+void SensorPrivate::SetRate(const ignition::msgs::Double& _rate)
+{
+  auto rate = _rate.data();
+  if (rate < 0.0)
+    rate = 0.0;
+
+  // if SDF has zero, any value can be set; for non-zero SDF values, we need to
+  // check whether they are in bounds, i.e. greater than zero and lower or equal
+  // to the SDF value
+  if (!ignition::math::lessOrNearEqual(this->sdfUpdateRate, 0.0))
+  {
+    if (ignition::math::lessOrNearEqual(rate, 0.0))
+    {
+      ignerr << "Cannot set update rate of sensor " << this->name << " to zero "
+             << "because the <update_rate> SDF element is non-zero."
+             << std::endl;
+      return;
+    }
+    // apply the upper rate limit from SDF
+    else if (!ignition::math::lessOrNearEqual(rate, this->sdfUpdateRate))
+    {
+      ignerr << "Trying to set update rate of sensor " << this->name << " to "
+             << rate << ", but the maximum rate in <update_rate> SDF element "
+             << "is " << this->sdfUpdateRate << ". Ignoring the request."
+             << std::endl;
+      return;
+    }
+  }
+
+  igndbg << "Setting update rate of sensor " << this->name << " to " << rate
+         << " Hz" << std::endl;
+
+  this->updateRate = rate;
 }
 
 //////////////////////////////////////////////////

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -19,6 +19,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/sensors/Export.hh>
 #include <ignition/sensors/Sensor.hh>
+#include <ignition/transport/Node.hh>
 
 using namespace ignition;
 using namespace sensors;
@@ -128,6 +129,140 @@ TEST(Sensor_TEST, Topic)
 
   EXPECT_FALSE(sensor.SetTopic(""));
 }
+
+//////////////////////////////////////////////////
+TEST(Sensor_TEST, SetRateService)
+{
+  std::ostringstream stream;
+  stream
+    << "<?xml version='1.0'?>"
+    << "<sdf version='1.6'>"
+    << " <model name='m1'>"
+    << "  <link name='link1'>"
+    << "    <sensor name='test' type='altimeter'>"
+    << "      <topic>test_topic</topic>"
+    << "      <update_rate>10.0</update_rate>"
+    << "    </sensor>"
+    << "  </link>"
+    << " </model>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  ASSERT_TRUE(sdf::readString(stream.str(), sdfParsed));
+
+  TestSensor sensor;
+  ASSERT_TRUE(sensor.Load(
+    sdfParsed->Root()->GetElement("model")->GetElement("link")
+      ->GetElement("sensor")));
+
+  EXPECT_EQ("test_topic", sensor.Topic());
+  EXPECT_FLOAT_EQ(10.0, sensor.UpdateRate());
+
+  ignition::transport::Node node;
+
+  std::vector<std::string> services;
+  node.ServiceList(services);
+  ASSERT_LT(0u, services.size());
+
+  const auto serviceIt =
+    std::find(services.begin(), services.end(), "/test_topic/set_rate");
+  ASSERT_NE(services.end(), serviceIt);
+
+  std::vector<ignition::transport::ServicePublisher> publishers;
+  ASSERT_TRUE(node.ServiceInfo("/test_topic/set_rate", publishers));
+
+  ASSERT_LT(0u, publishers.size());
+
+  ignition::msgs::Double msg;
+  ignition::msgs::Empty rep;
+  bool res;
+
+  // can set value lower than in SDF
+  msg.set_data(5.0);
+  res = false;
+  EXPECT_TRUE(node.Request("/test_topic/set_rate", msg, 1000, rep, res));
+  EXPECT_TRUE(res);
+
+  EXPECT_FLOAT_EQ(5.0, sensor.UpdateRate());
+
+  // cannot set 0 if SDF has non-zero
+  msg.set_data(0.0);
+  res = false;
+  EXPECT_TRUE(node.Request("/test_topic/set_rate", msg, 1000, rep, res));
+  EXPECT_TRUE(res);
+
+  EXPECT_FLOAT_EQ(5.0, sensor.UpdateRate());
+
+  // cannot set higher than SDF value
+  msg.set_data(20.0);
+  res = false;
+  EXPECT_TRUE(node.Request("/test_topic/set_rate", msg, 1000, rep, res));
+  EXPECT_TRUE(res);
+
+  EXPECT_FLOAT_EQ(5.0, sensor.UpdateRate());
+}
+
+//////////////////////////////////////////////////
+TEST(Sensor_TEST, SetRateZeroService)
+{
+  std::ostringstream stream;
+  stream
+    << "<?xml version='1.0'?>"
+    << "<sdf version='1.6'>"
+    << " <model name='m1'>"
+    << "  <link name='link1'>"
+    << "    <sensor name='test' type='altimeter'>"
+    << "      <topic>test_topic2</topic>"
+    << "      <update_rate>0.0</update_rate>"
+    << "    </sensor>"
+    << "  </link>"
+    << " </model>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  ASSERT_TRUE(sdf::readString(stream.str(), sdfParsed));
+
+  TestSensor sensor;
+  ASSERT_TRUE(sensor.Load(
+    sdfParsed->Root()->GetElement("model")->GetElement("link")
+      ->GetElement("sensor")));
+
+  EXPECT_EQ("test_topic2", sensor.Topic());
+  EXPECT_FLOAT_EQ(0.0, sensor.UpdateRate());
+
+  ignition::transport::Node node;
+
+  ignition::msgs::Double msg;
+  ignition::msgs::Empty rep;
+  bool res;
+
+  // can set any value if SDF has 0
+  msg.set_data(5.0);
+  res = false;
+  EXPECT_TRUE(node.Request("/test_topic2/set_rate", msg, 1000, rep, res));
+  EXPECT_TRUE(res);
+
+  EXPECT_FLOAT_EQ(5.0, sensor.UpdateRate());
+
+  // can set 0 if SDF has zero
+  msg.set_data(0.0);
+  res = false;
+  EXPECT_TRUE(node.Request("/test_topic2/set_rate", msg, 1000, rep, res));
+  EXPECT_TRUE(res);
+
+  EXPECT_FLOAT_EQ(0.0, sensor.UpdateRate());
+
+  // can set any value if SDF has 0
+  msg.set_data(20.0);
+  res = false;
+  EXPECT_TRUE(node.Request("/test_topic2/set_rate", msg, 1000, rep, res));
+  EXPECT_TRUE(res);
+
+  EXPECT_FLOAT_EQ(20.0, sensor.UpdateRate());
+}
+
 
 //////////////////////////////////////////////////
 int main(int argc, char **argv)


### PR DESCRIPTION
# New feature

Helps with issue #81 and https://github.com/osrf/subt/issues/680 (for some users).

## Summary

This PR adds an Ignition Transport service `~/set_rate` to all sensors. This is to allow users to selectively slow down some sensors if they do not need them running at full rate. This is extremely helpful with rendering sensors when you can anyways process only 6 Hz or similar, but the sensors run on 30.

I also made the service check if the caller doesn't want to set a higher rate than the value of `<update_rate>` in the sensor's SDF. Such attempts are ignored (with the exception of zero update rate in SDF, which allows to set any rate via this service).

I added a unit test and also tested it running the SubT simulator with EXPLORER_X1_SENSOR_CONFIG_2. This robot has 4 RGBD cameras, and the set_rate service worked for all of them. A single call to set_rate slows down both RGB and D cameras in the RGBD sensor. The real-time ratio of the SubT simulator with the robot was about 20-30% when spawned, and increased to about 90% when I slowed down all 4 cameras to 6 Hz. This might possibly save a lot of money for running Cloudsim :)

I decided to not limit the PR to rendering sensors, where the benefit is obvious, but as `<update_rate>` is a generic property of all sensors, I also added the service at this level.

## Test it

Terminal 1:

    ign launch -v4 cloudsim_sim.ign worldName:=simple_cave_01 robotName1:=X1 robotConfig1:=EXPLORER_X1_SENSOR_CONFIG_2 headless:=false

Terminal 2:

    ign launch -v4 cloudsim_bridge.ign robotName1:=X1 robotConfig1:=EXPLORER_X1_SENSOR_CONFIG_2 worldName:=simple_cave_01

Terminal 3:

    for s in front rear left right; do IGN_TRANSPORT_TOPIC_STATISTICS=1 ign service -s /world/simple_cave_01/model/X1/link/base_link/sensor/${s}_realsense/set_rate --reqtype ignition.msgs.Double --reptype ignition.msgs.Empty --timeout 200 -r 'data: 6.0'; done

Running the bridge makes sure all cameras have a subscriber and generate data. This should slow down the simulation to sub-realtime. When you call the services to slow down the cameras, simulation speed should attack real time. You'll also see this in the simulator console:

```
[Dbg] [Sensor.cc:266] Setting update rate of sensor X1::base_link::front_realsense to 6 Hz
[Dbg] [Sensor.cc:266] Setting update rate of sensor X1::base_link::rear_realsense to 6 Hz
[Dbg] [Sensor.cc:266] Setting update rate of sensor X1::base_link::left_realsense to 6 Hz
[Dbg] [Sensor.cc:266] Setting update rate of sensor X1::base_link::right_realsense to 6 Hz
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See
  [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**