### PR TITLE
Support custom sensors

### DIFF
--- a/examples/custom_sensor/CMakeLists.txt
+++ b/examples/custom_sensor/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+
+find_package(ignition-cmake2 REQUIRED)
+
+# Must follow the pattern "ignition-sensors<MAJOR_VERSION>-<SENSOR_TYPE>"
+project(ignition-sensors5-custom_sensor)
+
+find_package(ignition-plugin1 REQUIRED COMPONENTS register)
+find_package(ignition-sensors5 REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED CustomSensor.cc)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE ignition-plugin1::ignition-plugin1
+  PRIVATE ignition-sensors5::ignition-sensors5)

--- a/examples/custom_sensor/CustomSensor.cc
+++ b/examples/custom_sensor/CustomSensor.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <ignition/msgs/double.pb.h>
+
+#include <ignition/common/Console.hh>
+#include <ignition/plugin/Register.hh>
+#include <ignition/sensors/Noise.hh>
+#include <ignition/sensors/SensorFactory.hh>
+
+#include "CustomSensor.hh"
+
+using namespace custom;
+
+//////////////////////////////////////////////////
+bool CustomSensor::Load(sdf::ElementPtr _sdf)
+{
+  if (!_sdf)
+  {
+    ignerr << "Null SDF pointer." << std::endl;
+    return false;
+  }
+
+  if (_sdf->GetName() != "sensor")
+  {
+    ignerr << "SDF element is not a sensor." << std::endl;
+    return false;
+  }
+
+  std::string type = _sdf->Get<std::string>("type");
+  if (type != "custom_sensor")
+  {
+    ignerr << "Trying to load [custom_sensor], got [" << type << "] instead."
+           << std::endl;
+    return false;
+  }
+
+  // Load common sensor params
+  ignition::sensors::Sensor::Load(_sdf);
+
+  // Load noise
+  if (_sdf->HasElement("noise"))
+  {
+    sdf::Noise noiseSdf;
+    noiseSdf.Load(_sdf->GetElement("noise"));
+    this->noise = ignition::sensors::NoiseFactory::NewNoiseModel(noiseSdf);
+  }
+
+  // Advertise topic where data will be published
+  this->pub = this->node.Advertise<ignition::msgs::Double>(this->Topic());
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool CustomSensor::Update(const std::chrono::steady_clock::duration &_now)
+{
+  ignition::msgs::Double msg;
+  *msg.mutable_header()->mutable_stamp() = ignition::msgs::Convert(_now);
+  auto frame = msg.mutable_header()->add_data();
+  frame->set_key("frame_id");
+  frame->add_value(this->Name());
+
+  this->data = this->noise->Apply(this->data);
+
+  msg.set_data(this->data);
+
+  this->AddSequence(msg.mutable_header());
+  this->pub.Publish(msg);
+
+  return true;
+}
+
+IGNITION_ADD_PLUGIN(
+    ignition::sensors::SensorTypePlugin<custom::CustomSensor>,
+    ignition::sensors::SensorPlugin)
+IGNITION_ADD_PLUGIN_ALIAS(
+    ignition::sensors::SensorTypePlugin<custom::CustomSensor>,
+    "custom_sensor")

--- a/examples/custom_sensor/CustomSensor.hh
+++ b/examples/custom_sensor/CustomSensor.hh
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef CUSTOMSENSORSENSOR_HH_
+#define CUSTOMSENSORSENSOR_HH_
+
+#include <ignition/sensors/Sensor.hh>
+#include <ignition/sensors/SensorTypes.hh>
+#include <ignition/transport/Node.hh>
+
+namespace custom
+{
+  /// \brief CustomSensor Sensor Class
+  class CustomSensor : public ignition::sensors::Sensor
+  {
+    /// \brief Load the sensor with SDF parameters.
+    /// \param[in] _sdf SDF Sensor parameters.
+    /// \return true if loading was successful
+    public: virtual bool Load(sdf::ElementPtr _sdf) override;
+
+    /// \brief Update the sensor and generate data
+    /// \param[in] _now The current time
+    /// \return True if the update was successfull
+    public: virtual bool Update(
+      const std::chrono::steady_clock::duration &_now) override;
+
+    /// \brief Noise that will be applied to the sensor data
+    private: ignition::sensors::NoisePtr noise;
+
+    /// \brief Node for communication
+    private: ignition::transport::Node node;
+
+    /// \brief Publishes sensor data
+    private: ignition::transport::Node::Publisher pub;
+
+    /// \brief Latest data
+    private: double data{0.0};
+  };
+}
+
+#endif

--- a/examples/custom_sensor/README.md
+++ b/examples/custom_sensor/README.md
@@ -1,0 +1,23 @@
+# Custom sensor
+
+This example creates a simple custom sensor that produces a single number as
+data and publishes it to a topic.
+
+## Build
+
+Compile the sensor as follows:
+
+```
+cd examples/custom_sensor
+mkdir build
+cd build
+cmake ..
+make
+```
+
+This will generate a shared library with the sensor called `ignition-sensors5-custom_sensor`.
+
+## Test
+
+The "loop_sensor" example can be used to load an SDF file with configuration for
+this sensor and run it in a loop. See that example's instructions.

--- a/examples/custom_sensor/custom_sensor.sdf
+++ b/examples/custom_sensor/custom_sensor.sdf
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="my_model">
+    <link name="my_link">
+      <sensor name="my_sensor" type="custom_sensor">
+        <update_rate>10</update_rate>
+        <topic>/custom_data</topic>
+        <noise>
+          <type>gaussian</type>
+          <mean>1.0</mean>
+          <stddev>0.05</stddev>
+        </noise>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/examples/loop_sensor/CMakeLists.txt
+++ b/examples/loop_sensor/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+project(loop_sensor)
+
+find_package(ignition-sensors5 REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cc)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ignition-sensors5::ignition-sensors5)

--- a/examples/loop_sensor/README.md
+++ b/examples/loop_sensor/README.md
@@ -1,0 +1,163 @@
+# Loop sensor
+
+Example executable that loads a sensor from an SDF file and updates it in a
+loop until the user closes the program.
+
+This example can't load rendering sensors.
+
+## Build
+
+Compile as follows:
+
+```
+cd examples/loop_sensor
+mkdir build
+cd build
+cmake ..
+make
+```
+
+This will generate an executable called `loop_sensor`.
+
+## Load an official sensor
+
+Try for example loading the accompanying `altimeter_sensor.sdf` file to run
+an altimeter sensor, which is installed with Ignition Sensors:
+
+```
+cd examples/loop_sensor/build
+./loop_sensor ../altimeter_example.sdf
+```
+
+On another terminal, check that the altimeter is generating data on a topic:
+
+```
+ign topic -l
+```
+
+You should see:
+
+``
+/altimeter
+```
+
+Then listen to the data:
+
+```
+ign topic -e -t /altimeter
+```
+
+You'll see data like:
+
+```
+...
+header {
+  stamp {
+    sec: 12
+  }
+  data {
+    key: "frame_id"
+    value: "altimeter"
+  }
+  data {
+    key: "seq"
+    value: "12"
+  }
+}
+vertical_position: 0.9903850972191578
+vertical_velocity: 2.9159486154028573
+
+header {
+  stamp {
+    sec: 13
+  }
+  data {
+    key: "frame_id"
+    value: "altimeter"
+  }
+  data {
+    key: "seq"
+    value: "13"
+  }
+}
+vertical_position: 1.139457534900868
+vertical_velocity: 3.1484160275030266
+...
+```
+
+## Load a custom sensor
+
+Let's try loading the sensor from the `custom_sensor` example.
+
+First we need to tell Ignition Sensors where to find the custom sensor
+by setting the `IGN_SENSORS_PATH` environment variable to the path where
+`ignition-sensors5-custom_sensor` is located:
+
+```
+cd examples/loop_sensor/build
+export IGN_SENSORS_PATH=../..//custom_sensor/build
+```
+
+Then we can run the `custom_sensor.sdf` file provided with that sensor:
+
+```
+cd examples/loop_sensor/build
+./loop_sensor ../../custom_sensor/custom_sensor.sdf
+```
+
+On another terminal, check that the sensor is generating data on a topic:
+
+```
+ign topic -l
+```
+
+You should see:
+
+``
+/custom_data
+```
+
+Then listen to the data:
+
+```
+ign topic -e -t /custom_data
+```
+
+You'll see data like:
+
+```
+...
+header {
+  stamp {
+    sec: 12
+  }
+  data {
+    key: "frame_id"
+    value: "my_sensor"
+  }
+  data {
+    key: "seq"
+    value: "12"
+  }
+}
+data: 12.799322041404857
+
+header {
+  stamp {
+    sec: 13
+  }
+  data {
+    key: "frame_id"
+    value: "my_sensor"
+  }
+  data {
+    key: "seq"
+    value: "13"
+  }
+}
+data: 13.783310442250663
+...
+```
+
+
+

--- a/examples/loop_sensor/altimeter_example.sdf
+++ b/examples/loop_sensor/altimeter_example.sdf
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="my_model">
+    <link name="my_link">
+      <sensor name="altimeter" type="altimeter">
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>true</visualize>
+        <topic>altimeter</topic>
+        <altimeter>
+          <vertical_position>
+            <noise type="gaussian">
+              <mean>0.1</mean>
+              <stddev>0.2</stddev>
+            </noise>
+          </vertical_position>
+          <vertical_velocity>
+            <noise type="gaussian">
+              <mean>0.2</mean>
+              <stddev>0.1</stddev>
+            </noise>
+          </vertical_velocity>
+        </altimeter>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/examples/loop_sensor/main.cc
+++ b/examples/loop_sensor/main.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2017 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <fstream>
+#include <iostream>
+
+#include <sdf/Sensor.hh>
+
+#include <ignition/common/Console.hh>
+#include <ignition/common/SignalHandler.hh>
+
+#include <ignition/sensors/Manager.hh>
+
+using namespace std::literals::chrono_literals;
+
+int main(int argc,  char **argv)
+{
+  ignition::common::Console::SetVerbosity(4);
+
+  if (argc < 2)
+  {
+    ignerr << "Missing path to SDF file" << std::endl;
+    return 1;
+  }
+
+  // Load file
+  std::string sdfFile(argv[1]);
+  std::ifstream fileStream(sdfFile, std::ifstream::in);
+
+  std::string sdfString((std::istreambuf_iterator<char>(fileStream)),
+                         std::istreambuf_iterator<char>());
+  fileStream.close();
+
+  // Read SDF
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  if (!sdf::readString(sdfString, sdfParsed))
+  {
+    ignerr << "Failed to parse SDF: " << std::endl << sdfString << std::endl;
+    return 1;
+  }
+  if (!sdfParsed ||
+      !sdfParsed->Root() ||
+      !sdfParsed->Root()->GetElement("model") ||
+      !sdfParsed->Root()->GetElement("model")->GetElement("link") ||
+      !sdfParsed->Root()->GetElement("model")->GetElement("link")->GetElement("sensor"))
+  {
+    ignerr << "Failed to find sensor in SDF" << std::endl;
+    return 1;
+  }
+
+  auto sdfElem = sdfParsed->Root()->GetElement("model")->GetElement("link")
+    ->GetElement("sensor");
+
+  // Create sensor
+  ignition::sensors::Manager mgr;
+  auto sensor = mgr.CreateSensor(sdfElem);
+
+  if (!sensor)
+  {
+    ignerr << "Unable to load sensor" << std::endl;;
+    return 1;
+  }
+
+  // Stop when user presses Ctrl+C
+  bool signaled{false};
+  ignition::common::SignalHandler sigHandler;
+  sigHandler.AddCallback([&] (int)
+  {
+    signaled = true;
+  });
+
+  auto time = 0s;
+  while (!signaled)
+  {
+    mgr.RunOnce(time, true);
+    time += 1s;
+    std::this_thread::sleep_for(1s);
+  }
+
+  return 0;
+}

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -90,8 +90,12 @@ namespace ignition
       /// \param[in] _now The current time
       /// \return true if the update was successfull
       /// \sa SetUpdateRate()
+      /// \deprecated Use `Update` function that accepts chrono.
       public:
-        virtual bool IGN_DEPRECATED(4) Update(const common::Time &_now) = 0;
+        virtual bool IGN_DEPRECATED(4) Update(const common::Time &/*_now*/)
+        {
+          return false;
+        };
 
       /// \brief Force the sensor to generate data
       ///

--- a/src/SensorFactory.cc
+++ b/src/SensorFactory.cc
@@ -35,6 +35,9 @@ class ignition::sensors::SensorFactoryPrivate
 
   /// \brief Stores paths to search for on file system
   public: ignition::common::SystemPaths systemPaths;
+
+  /// \brief Environment variable containing lookup paths for sensors.
+  public: const std::string pathEnv{"IGN_SENSORS_PATH"};
 };
 
 using namespace ignition;
@@ -55,6 +58,7 @@ void SensorFactory::AddPluginPaths(const std::string &_path)
 //////////////////////////////////////////////////
 SensorFactory::SensorFactory() : dataPtr(new SensorFactoryPrivate)
 {
+  this->dataPtr->systemPaths.SetPluginPathEnv(this->dataPtr->pathEnv);
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Closes #9

Builds on top of #90 

## Summary

Add support for custom sensors that aren't installed together with `ign-sensors`, so that external users can implement their own sensors. This adds:

* The environment variable `IGN_SENSORS_PATH` that users can set to find sensors.
* An example with a custom sensor
* An example with an executable that can loop any non-rendering sensor, and can be used to test the custom sensor

It also makes the deprecated `Update` function non-pure-virtual, so downstream developers aren't forced to implement a deprecated function. 

I decided to work on this to validate that the work being done on #90 was flexible enough to support external sensors.

## Test it

Follow the instructions on each example's READMEs.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests :warning: TODO
- [ ] Added example and/or tutorial :warning: TODO I want to move the READMEs to `tutorials`
- [ ] Updated documentation (as needed) :warning: TODO document `IGN_SENSORS_PATH` somewhere
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**