### PR TITLE
Bump main to 6.0.0~pre1

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@ jobs:
   build:
 
     env:
-      PACKAGE: ignition-sensors5
+      PACKAGE: ignition-sensors6
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-sensors5 VERSION 5.0.0)
+project(ignition-sensors6 VERSION 6.0.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -13,7 +13,7 @@ find_package(ignition-cmake2 REQUIRED)
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project(VERSION_SUFFIX pre2)
+ign_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Ignition Sensors 6
+
+### Ignition Sensors 6.X.X
+
+### Ignition Sensors 6.0.0 (20XX-XX-XX)
+
 ## Ignition Sensors 5
 
 ### Ignition Sensors 5.X.X

--- a/examples/imu_noise/CMakeLists.txt
+++ b/examples/imu_noise/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(ignition-sensors-noise-demo)
 
 # Find the Ignition Libraries used directly by the example
-find_package(ignition-sensors5 REQUIRED)
+find_package(ignition-sensors6 REQUIRED)
 
 add_executable(sensor_noise main.cc)
-target_link_libraries(sensor_noise PUBLIC ignition-sensors5)
+target_link_libraries(sensor_noise PUBLIC ignition-sensors6)

--- a/examples/save_image/CMakeLists.txt
+++ b/examples/save_image/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ignition-sensors-camera-demo)
 
 # Find the Ignition Libraries used directly by the example
 find_package(ignition-rendering5 REQUIRED OPTIONAL_COMPONENTS ogre ogre2)
-find_package(ignition-sensors5 REQUIRED COMPONENTS rendering camera)
+find_package(ignition-sensors6 REQUIRED COMPONENTS rendering camera)
 
 if (TARGET ignition-rendering5::ogre)
    add_definitions(-DWITH_OGRE)
@@ -14,4 +14,4 @@ endif()
 
 add_executable(save_image main.cc)
 target_link_libraries(save_image PUBLIC
-  ignition-sensors5::camera)
+  ignition-sensors6::camera)


### PR DESCRIPTION
Branch `ign-sensors5` has been created for the Edifice release and 5.0.0 released from that.

The `main` branch now corresponds to version 6.0.0~pre1, and nightlies will soon be created from this branch.

https://github.com/ignition-tooling/release-tools/issues/421