### PR TITLE
👩‍🌾 Disable tests that consistently fail on macOS

### DIFF
--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -801,7 +801,9 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   // Sensor 2 should see box01 to the right of it
   EXPECT_NEAR(sensor2->Range(0), expectedRangeAtMidPointBox1, LASER_TOL);
   EXPECT_DOUBLE_EQ(sensor2->Range(mid), ignition::math::INF_D);
+#ifndef __APPLE__
   EXPECT_DOUBLE_EQ(sensor2->Range(last), ignition::math::INF_D);
+#endif
 
   // Clean up
   //

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -539,6 +539,7 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   EXPECT_NEAR(sensor1->Range(0), expectedRangeAtMidPointBox2, LASER_TOL);
   EXPECT_NEAR(sensor1->Range(mid), expectedRangeAtMidPointBox1, LASER_TOL);
 #ifndef __APPLE__
+  // See https://github.com/ignitionrobotics/ign-sensors/issues/66
   EXPECT_DOUBLE_EQ(sensor1->Range(last), ignition::math::INF_D);
 #endif
 
@@ -655,6 +656,7 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
     double expectedRange = expectedRangeAtMidPoint / cos(angleStep);
 
 #ifndef __APPLE__
+    // See https://github.com/ignitionrobotics/ign-sensors/issues/66
     EXPECT_NEAR(sensor->Range(i * horzSamples + mid),
         expectedRange, VERTICAL_LASER_TOL);
 #endif
@@ -795,6 +797,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   EXPECT_DOUBLE_EQ(sensor1->Range(0), ignition::math::INF_D);
   EXPECT_NEAR(sensor1->Range(mid), expectedRangeAtMidPointBox1, LASER_TOL);
 #ifndef __APPLE__
+  // See https://github.com/ignitionrobotics/ign-sensors/issues/66
   EXPECT_DOUBLE_EQ(sensor1->Range(last), ignition::math::INF_D);
 #endif
 
@@ -802,6 +805,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   EXPECT_NEAR(sensor2->Range(0), expectedRangeAtMidPointBox1, LASER_TOL);
   EXPECT_DOUBLE_EQ(sensor2->Range(mid), ignition::math::INF_D);
 #ifndef __APPLE__
+  // See https://github.com/ignitionrobotics/ign-sensors/issues/66
   EXPECT_DOUBLE_EQ(sensor2->Range(last), ignition::math::INF_D);
 #endif
 

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -538,7 +538,7 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   // Sensor 1 should see box01 and box02
   EXPECT_NEAR(sensor1->Range(0), expectedRangeAtMidPointBox2, LASER_TOL);
   EXPECT_NEAR(sensor1->Range(mid), expectedRangeAtMidPointBox1, LASER_TOL);
-#ifdef __APPLE__
+#ifndef __APPLE__
   EXPECT_DOUBLE_EQ(sensor1->Range(last), ignition::math::INF_D);
 #endif
 
@@ -654,7 +654,7 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
   {
     double expectedRange = expectedRangeAtMidPoint / cos(angleStep);
 
-#ifdef __APPLE__
+#ifndef __APPLE__
     EXPECT_NEAR(sensor->Range(i * horzSamples + mid),
         expectedRange, VERTICAL_LASER_TOL);
 #endif
@@ -794,7 +794,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   // Sensor 1 should see box01 in front of it
   EXPECT_DOUBLE_EQ(sensor1->Range(0), ignition::math::INF_D);
   EXPECT_NEAR(sensor1->Range(mid), expectedRangeAtMidPointBox1, LASER_TOL);
-#ifdef __APPLE__
+#ifndef __APPLE__
   EXPECT_DOUBLE_EQ(sensor1->Range(last), ignition::math::INF_D);
 #endif
 

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -538,7 +538,9 @@ void GpuLidarSensorTest::TestThreeBoxes(const std::string &_renderEngine)
   // Sensor 1 should see box01 and box02
   EXPECT_NEAR(sensor1->Range(0), expectedRangeAtMidPointBox2, LASER_TOL);
   EXPECT_NEAR(sensor1->Range(mid), expectedRangeAtMidPointBox1, LASER_TOL);
+#ifdef __APPLE__
   EXPECT_DOUBLE_EQ(sensor1->Range(last), ignition::math::INF_D);
+#endif
 
   // Only box01 should be visible to sensor 2
   EXPECT_DOUBLE_EQ(sensor2->Range(0), ignition::math::INF_D);
@@ -652,8 +654,10 @@ void GpuLidarSensorTest::VerticalLidar(const std::string &_renderEngine)
   {
     double expectedRange = expectedRangeAtMidPoint / cos(angleStep);
 
+#ifdef __APPLE__
     EXPECT_NEAR(sensor->Range(i * horzSamples + mid),
         expectedRange, VERTICAL_LASER_TOL);
+#endif
 
     angleStep += vAngleStep;
 
@@ -790,7 +794,9 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   // Sensor 1 should see box01 in front of it
   EXPECT_DOUBLE_EQ(sensor1->Range(0), ignition::math::INF_D);
   EXPECT_NEAR(sensor1->Range(mid), expectedRangeAtMidPointBox1, LASER_TOL);
+#ifdef __APPLE__
   EXPECT_DOUBLE_EQ(sensor1->Range(last), ignition::math::INF_D);
+#endif
 
   // Sensor 2 should see box01 to the right of it
   EXPECT_NEAR(sensor2->Range(0), expectedRangeAtMidPointBox1, LASER_TOL);

--- a/test/integration/rgbd_camera_plugin.cc
+++ b/test/integration/rgbd_camera_plugin.cc
@@ -374,6 +374,7 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
     EXPECT_EQ(0u, mr);
     EXPECT_EQ(0u, mg);
 #ifndef __APPLE__
+    // See https://github.com/ignitionrobotics/ign-sensors/issues/66
     EXPECT_GT(mb, 0u);
 #endif
 
@@ -439,6 +440,7 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
     EXPECT_EQ(0u, mr);
     EXPECT_EQ(0u, mg);
 #ifndef __APPLE__
+    // See https://github.com/ignitionrobotics/ign-sensors/issues/66
     EXPECT_GT(mb, 0u);
 #endif
 

--- a/test/integration/rgbd_camera_plugin.cc
+++ b/test/integration/rgbd_camera_plugin.cc
@@ -373,7 +373,7 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
     unsigned int mb = g_imgBuffer[imgMid + 2];
     EXPECT_EQ(0u, mr);
     EXPECT_EQ(0u, mg);
-#ifdef __APPLE__
+#ifndef __APPLE__
     EXPECT_GT(mb, 0u);
 #endif
 
@@ -438,7 +438,7 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
     unsigned int mb = g_pointsRGBBuffer[imgMid + 2];
     EXPECT_EQ(0u, mr);
     EXPECT_EQ(0u, mg);
-#ifdef __APPLE__
+#ifndef __APPLE__
     EXPECT_GT(mb, 0u);
 #endif
 

--- a/test/integration/rgbd_camera_plugin.cc
+++ b/test/integration/rgbd_camera_plugin.cc
@@ -373,7 +373,9 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
     unsigned int mb = g_imgBuffer[imgMid + 2];
     EXPECT_EQ(0u, mr);
     EXPECT_EQ(0u, mg);
+#ifdef __APPLE__
     EXPECT_GT(mb, 0u);
+#endif
 
     unsigned int lr = g_imgBuffer[imgLeft];
     unsigned int lg = g_imgBuffer[imgLeft + 1];
@@ -436,7 +438,9 @@ void RgbdCameraSensorTest::ImagesWithBuiltinSDF(
     unsigned int mb = g_pointsRGBBuffer[imgMid + 2];
     EXPECT_EQ(0u, mr);
     EXPECT_EQ(0u, mg);
+#ifdef __APPLE__
     EXPECT_GT(mb, 0u);
+#endif
 
     // Far left and right points should be red (background color)
     unsigned int lr = g_pointsRGBBuffer[imgLeft];


### PR DESCRIPTION
# 🦟 Bug fix

See #66 and #67

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

These tests are known to fail on macOS consistently. We should disable tests in such cases, so that CI's regular state is green and new test failures are easier to spot.

I opted for just disabling the offending lines instead of the entire test because most of the expectations succeed.

Once this is in, we can make Homebrew CI checks required to merge PRs.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests (removed, actually :innocent: )
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

https://github.com/osrf/buildfarmer/issues/181
