### PR TITLE
Remove clamping from lidar noise

### DIFF
--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -211,6 +211,11 @@ void Lidar::ApplyNoise()
         int index = j * this->RayCount() + i;
         double range = this->laserBuffer[index*3];
         range = this->dataPtr->noises[LIDAR_NOISE]->Apply(range);
+        if (std::isfinite(range))
+        {
+          range = ignition::math::clamp(range,
+            this->RangeMin(), this->RangeMax());
+        }
         this->laserBuffer[index*3] = range;
       }
     }

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -211,8 +211,6 @@ void Lidar::ApplyNoise()
         int index = j * this->RayCount() + i;
         double range = this->laserBuffer[index*3];
         range = this->dataPtr->noises[LIDAR_NOISE]->Apply(range);
-        range = ignition::math::clamp(range,
-            this->RangeMin(), this->RangeMax());
         this->laserBuffer[index*3] = range;
       }
     }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #131

## Summary
This PR removes clamping from application of lidar noise. The clamping generates wrong points for missed rays, as it clamps even the +-Inf values to the lidar range. Removing the clamping might lead to having some points with distance larger than `range_max` of the sensor, but I'd argue that's okay in case of noise. If not, then the code should explicitly check to not clamp infinite values.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**