### PR TITLE
Init will now set the nextUpdateTime to zero

### DIFF
--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -75,6 +75,9 @@ namespace ignition
       public: virtual bool Load(sdf::ElementPtr _sdf);
 
       /// \brief Initialize values in the sensor
+      /// This will set the next update time to zero. This is particularly
+      /// useful if simulation time has jumped backward, for example during
+      /// a seek backward in a log file.
       public: virtual bool Init();
 
       /// \brief Force the sensor to generate data

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -142,6 +142,7 @@ Sensor::Sensor() :
 //////////////////////////////////////////////////
 bool Sensor::Init()
 {
+  this->dataPtr->nextUpdateTime = std::chrono::steady_clock::duration::zero();
   return true;
 }
 


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

I needed a way to reset the `nextUpdateTime` to zero when seeking backward in a log file. Modifying `::Init` seemed convenient and unlikely to affect anyone. I can make a new function to accomplish the same goal if that is perferred.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**