### PR TITLE
Add API for enabling / disabling IMU orientation

### DIFF
--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -129,8 +129,8 @@ namespace ignition
       public: void SetGravity(const math::Vector3d &_gravity);
 
       /// \brief Set whether to output orientation. Not all imu's generate
-      /// orientation values as they use addition filters to produce
-      /// orientation estimates.
+      /// orientation values as they use filters to produce orientation
+      /// estimates.
       /// \param[in] _enabled True to publish orientation data, false to leave
       /// the message field empty.
       public: void SetOrientationEnabled(bool _enabled);

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -118,12 +118,26 @@ namespace ignition
       public: math::Quaterniond OrientationReference() const;
 
       /// \brief Get the orienation of the imu with respect to reference frame
-      /// \return Orientation in reference frame
+      /// \return Orientation in reference frame. If orientation is not
+      /// enabled, this will return the last computed orientation before
+      /// orientation is disabled or identity Quaternion if orientation has
+      /// never been enabled.
       public: math::Quaterniond Orientation() const;
 
       /// \brief Set the gravity vector
       /// \param[in] _gravity gravity vector in meters per second squared.
       public: void SetGravity(const math::Vector3d &_gravity);
+
+      /// \brief Set whether to output orientation. Not all imu's generate
+      /// orientation values as they use addition filters to produce
+      /// orientation estimates.
+      /// \param[in] _enabled True to publish orientation data, false to leave
+      /// the message field empty.
+      public: void SetOrientationEnabled(bool _enabled);
+
+      /// \brief Get whether or not orientation is enabled.
+      /// \return True if orientation is enabled, false otherwise.
+      public: bool OrientationEnabled() const;
 
       /// \brief Get the gravity vector
       /// \return Gravity vectory in meters per second squared.

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -59,6 +59,9 @@ class ignition::sensors::ImuSensorPrivate
   /// \brief transform to Imu frame from Imu reference frame.
   public: ignition::math::Quaterniond orientation;
 
+  /// \brief True to publish orientation data.
+  public: bool orientationEnabled = true;
+
   /// \brief store gravity vector to be added to the IMU output.
   public: ignition::math::Vector3d gravity;
 
@@ -211,12 +214,6 @@ bool ImuSensor::Update(const std::chrono::steady_clock::duration &_now)
   applyNoise(GYROSCOPE_Y_NOISE_RAD_S, this->dataPtr->angularVel.Y());
   applyNoise(GYROSCOPE_Z_NOISE_RAD_S, this->dataPtr->angularVel.Z());
 
-  // Set the IMU orientation
-  // imu orientation with respect to reference frame
-  this->dataPtr->orientation =
-      this->dataPtr->orientationReference.Inverse() *
-      this->dataPtr->worldPose.Rot();
-
   msgs::IMU msg;
   *msg.mutable_header()->mutable_stamp() = msgs::Convert(_now);
   msg.set_entity_name(this->Name());
@@ -224,7 +221,16 @@ bool ImuSensor::Update(const std::chrono::steady_clock::duration &_now)
   frame->set_key("frame_id");
   frame->add_value(this->Name());
 
-  msgs::Set(msg.mutable_orientation(), this->dataPtr->orientation);
+  if (this->dataPtr->orientationEnabled)
+  {
+    // Set the IMU orientation
+    // imu orientation with respect to reference frame
+    this->dataPtr->orientation =
+        this->dataPtr->orientationReference.Inverse() *
+        this->dataPtr->worldPose.Rot();
+
+    msgs::Set(msg.mutable_orientation(), this->dataPtr->orientation);
+  }
   msgs::Set(msg.mutable_angular_velocity(), this->dataPtr->angularVel);
   msgs::Set(msg.mutable_linear_acceleration(), this->dataPtr->linearAcc);
 
@@ -282,6 +288,18 @@ void ImuSensor::SetOrientationReference(const math::Quaterniond &_orient)
 math::Quaterniond ImuSensor::OrientationReference() const
 {
   return this->dataPtr->orientationReference;
+}
+
+//////////////////////////////////////////////////
+void ImuSensor::SetOrientationEnabled(bool _enabled)
+{
+  this->dataPtr->orientationEnabled = _enabled;
+}
+
+//////////////////////////////////////////////////
+bool ImuSensor::OrientationEnabled() const
+{
+  return this->dataPtr->orientationEnabled;
 }
 
 //////////////////////////////////////////////////

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -317,76 +317,77 @@ TEST(ImuSensor_TEST, Orientation)
   // Create a sensor manager
   ignition::sensors::Manager mgr;
 
-  sdf::ElementPtr imuSDF, imuSDF_truth;
+  sdf::ElementPtr imuSDF;
 
   {
     const std::string name = "TestImu_Truth";
     const std::string topic = "/ignition/sensors/test/imu_truth";
-    const double update_rate = 100;
-    const auto accelNoise = noNoiseParameters(update_rate, 0.0);
-    const auto gyroNoise = noNoiseParameters(update_rate, 0.0);
+    const double updateRate = 100;
+    const auto accelNoise = noNoiseParameters(updateRate, 0.0);
+    const auto gyroNoise = noNoiseParameters(updateRate, 0.0);
     const bool always_on = 1;
     const bool visualize = 1;
 
-    imuSDF_truth = ImuSensorToSDF(name, update_rate, topic,
+    imuSDF = ImuSensorToSDF(name, updateRate, topic,
       accelNoise, gyroNoise, always_on, visualize);
   }
 
   // Create an ImuSensor
-  auto sensor_truth = mgr.CreateSensor<ignition::sensors::ImuSensor>(
-      imuSDF_truth);
+  auto sensor = mgr.CreateSensor<ignition::sensors::ImuSensor>(
+      imuSDF);
 
   // Make sure the above dynamic cast worked.
-  ASSERT_NE(nullptr, sensor_truth);
+  ASSERT_NE(nullptr, sensor);
 
   math::Quaterniond orientRef;
   math::Quaterniond orientValue(math::Vector3d(IGN_PI/2.0, 0, IGN_PI));
   math::Pose3d pose(math::Vector3d(0, 1, 2), orientValue);
 
-  sensor_truth->SetOrientationReference(orientRef);
-  sensor_truth->SetWorldPose(pose);
+  sensor->SetOrientationReference(orientRef);
+  sensor->SetWorldPose(pose);
 
-  sensor_truth->Update(std::chrono::steady_clock::duration(
+  sensor->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
 
   // Check orientation
-  EXPECT_TRUE(sensor_truth->OrientationEnabled());
-  EXPECT_EQ(orientRef, sensor_truth->OrientationReference());
-  EXPECT_EQ(orientValue, sensor_truth->Orientation());
+  EXPECT_TRUE(sensor->OrientationEnabled());
+  EXPECT_EQ(orientRef, sensor->OrientationReference());
+  EXPECT_EQ(orientValue, sensor->Orientation());
 
   // update pose and check orientation
   math::Quaterniond newOrientValue(math::Vector3d(IGN_PI, IGN_PI/2, IGN_PI));
   math::Pose3d newPose(math::Vector3d(0, 1, 1), newOrientValue);
-  sensor_truth->SetWorldPose(newPose);
+  sensor->SetWorldPose(newPose);
 
-  sensor_truth->Update(std::chrono::steady_clock::duration(
+  sensor->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(20000000)));
 
-  EXPECT_TRUE(sensor_truth->OrientationEnabled());
-  EXPECT_EQ(orientRef, sensor_truth->OrientationReference());
-  EXPECT_EQ(newOrientValue, sensor_truth->Orientation());
+  EXPECT_TRUE(sensor->OrientationEnabled());
+  EXPECT_EQ(orientRef, sensor->OrientationReference());
+  EXPECT_EQ(newOrientValue, sensor->Orientation());
 
   // disable orientation and check
-  sensor_truth->SetOrientationEnabled(false);
-  EXPECT_FALSE(sensor_truth->OrientationEnabled());
-  EXPECT_EQ(orientRef, sensor_truth->OrientationReference());
+  sensor->SetOrientationEnabled(false);
+  EXPECT_FALSE(sensor->OrientationEnabled());
+  EXPECT_EQ(orientRef, sensor->OrientationReference());
   // orientation remains the same after disabling orientation
-  EXPECT_EQ(newOrientValue, sensor_truth->Orientation());
+  EXPECT_EQ(newOrientValue, sensor->Orientation());
 
   // update world pose with orientation disabled and verify that orientation
   // does not change
   math::Quaterniond newOrientValue2(math::Vector3d(IGN_PI/2, IGN_PI/2, IGN_PI));
   math::Pose3d newPose2(math::Vector3d(1, 1, 0), newOrientValue2);
-  sensor_truth->SetWorldPose(newPose2);
-  sensor_truth->Update(std::chrono::steady_clock::duration(
+  sensor->SetWorldPose(newPose2);
+  sensor->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(20000000)));
 
-  sensor_truth->SetOrientationEnabled(false);
-  EXPECT_FALSE(sensor_truth->OrientationEnabled());
-  EXPECT_EQ(orientRef, sensor_truth->OrientationReference());
+  sensor->SetOrientationEnabled(false);
+  EXPECT_FALSE(sensor->OrientationEnabled());
+  EXPECT_EQ(orientRef, sensor->OrientationReference());
   // orientation should still be the previous value because it is not being
   // updated.
-  EXPECT_EQ(newOrientValue, sensor_truth->Orientation());
+  EXPECT_EQ(newOrientValue, sensor->Orientation());
+
 }
 
 //////////////////////////////////////////////////

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -311,6 +311,83 @@ TEST(ImuSensor_TEST, ComputeNoise)
   EXPECT_GT(sensor->LinearAcceleration().SquaredLength(), 0.0);
 }
 
+//////////////////////////////////////////////////
+TEST(ImuSensor_TEST, Orientation)
+{
+  // Create a sensor manager
+  ignition::sensors::Manager mgr;
+
+  sdf::ElementPtr imuSDF, imuSDF_truth;
+
+  {
+    const std::string name = "TestImu_Truth";
+    const std::string topic = "/ignition/sensors/test/imu_truth";
+    const double update_rate = 100;
+    const auto accelNoise = noNoiseParameters(update_rate, 0.0);
+    const auto gyroNoise = noNoiseParameters(update_rate, 0.0);
+    const bool always_on = 1;
+    const bool visualize = 1;
+
+    imuSDF_truth = ImuSensorToSDF(name, update_rate, topic,
+      accelNoise, gyroNoise, always_on, visualize);
+  }
+
+  // Create an ImuSensor
+  auto sensor_truth = mgr.CreateSensor<ignition::sensors::ImuSensor>(
+      imuSDF_truth);
+
+  // Make sure the above dynamic cast worked.
+  ASSERT_NE(nullptr, sensor_truth);
+
+  math::Quaterniond orientRef;
+  math::Quaterniond orientValue(math::Vector3d(IGN_PI/2.0, 0, IGN_PI));
+  math::Pose3d pose(math::Vector3d(0, 1, 2), orientValue);
+
+  sensor_truth->SetOrientationReference(orientRef);
+  sensor_truth->SetWorldPose(pose);
+
+  sensor_truth->Update(std::chrono::steady_clock::duration(
+    std::chrono::nanoseconds(10000000)));
+
+  // Check orientation
+  EXPECT_TRUE(sensor_truth->OrientationEnabled());
+  EXPECT_EQ(orientRef, sensor_truth->OrientationReference());
+  EXPECT_EQ(orientValue, sensor_truth->Orientation());
+
+  // update pose and check orientation
+  math::Quaterniond newOrientValue(math::Vector3d(IGN_PI, IGN_PI/2, IGN_PI));
+  math::Pose3d newPose(math::Vector3d(0, 1, 1), newOrientValue);
+  sensor_truth->SetWorldPose(newPose);
+
+  sensor_truth->Update(std::chrono::steady_clock::duration(
+    std::chrono::nanoseconds(20000000)));
+
+  EXPECT_TRUE(sensor_truth->OrientationEnabled());
+  EXPECT_EQ(orientRef, sensor_truth->OrientationReference());
+  EXPECT_EQ(newOrientValue, sensor_truth->Orientation());
+
+  // disable orientation and check
+  sensor_truth->SetOrientationEnabled(false);
+  EXPECT_FALSE(sensor_truth->OrientationEnabled());
+  EXPECT_EQ(orientRef, sensor_truth->OrientationReference());
+  // orientation remains the same after disabling orientation
+  EXPECT_EQ(newOrientValue, sensor_truth->Orientation());
+
+  // update world pose with orientation disabled and verify that orientation
+  // does not change
+  math::Quaterniond newOrientValue2(math::Vector3d(IGN_PI/2, IGN_PI/2, IGN_PI));
+  math::Pose3d newPose2(math::Vector3d(1, 1, 0), newOrientValue2);
+  sensor_truth->SetWorldPose(newPose2);
+  sensor_truth->Update(std::chrono::steady_clock::duration(
+    std::chrono::nanoseconds(20000000)));
+
+  sensor_truth->SetOrientationEnabled(false);
+  EXPECT_FALSE(sensor_truth->OrientationEnabled());
+  EXPECT_EQ(orientRef, sensor_truth->OrientationReference());
+  // orientation should still be the previous value because it is not being
+  // updated.
+  EXPECT_EQ(newOrientValue, sensor_truth->Orientation());
+}
 
 //////////////////////////////////////////////////
 int main(int argc, char **argv)


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

Not all IMUs produce orientation estimates. This PR adds a new API to the IMU sensor class to allow users to disable computing and publishing orientation values.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

