### PR TITLE
Make Sensors aware of CameraPassCountPerGpuFlush & Scene::PostFrame

### DIFF
--- a/src/RenderingSensor.cc
+++ b/src/RenderingSensor.cc
@@ -111,5 +111,13 @@ void RenderingSensor::Render()
       rc->PostRender();
     }
   }
+
+  if (!this->dataPtr->manualSceneUpdate &&
+      !this->dataPtr->scene->GetLegacyAutoGpuFlush())
+  {
+    // When GetLegacyAutoGpuFlush = true, that function gets
+    // called per sensor, so we don't have to do anything here
+    this->dataPtr->scene->PostRenderGpuFlush();
+  }
 }
 

--- a/src/RenderingSensor.cc
+++ b/src/RenderingSensor.cc
@@ -113,9 +113,9 @@ void RenderingSensor::Render()
   }
 
   if (!this->dataPtr->manualSceneUpdate &&
-      !this->dataPtr->scene->GetLegacyAutoGpuFlush())
+      !this->dataPtr->scene->LegacyAutoGpuFlush())
   {
-    // When GetLegacyAutoGpuFlush = true, that function gets
+    // When LegacyAutoGpuFlush = true, that function gets
     // called per sensor, so we don't have to do anything here
     this->dataPtr->scene->PostRender();
   }

--- a/src/RenderingSensor.cc
+++ b/src/RenderingSensor.cc
@@ -117,7 +117,7 @@ void RenderingSensor::Render()
   {
     // When GetLegacyAutoGpuFlush = true, that function gets
     // called per sensor, so we don't have to do anything here
-    this->dataPtr->scene->PostRenderGpuFlush();
+    this->dataPtr->scene->PostRender();
   }
 }
 

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -751,6 +751,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   ignition::rendering::VisualPtr root = scene->RootVisual();
 
   scene->SetAmbientLight(0.3, 0.3, 0.3);
+  scene->SetNumCameraPassesPerGpuFlush(6u);
 
   // Create a sensor manager
   ignition::sensors::Manager mgr;
@@ -790,6 +791,9 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
 
   // Render and update
   mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+
+  // manually finish update scene
+  scene->PostRender();
 
   int mid = horzSamples / 2;
   int last = (horzSamples - 1);

--- a/test/integration/gpu_lidar_sensor_plugin.cc
+++ b/test/integration/gpu_lidar_sensor_plugin.cc
@@ -751,7 +751,7 @@ void GpuLidarSensorTest::ManualUpdate(const std::string &_renderEngine)
   ignition::rendering::VisualPtr root = scene->RootVisual();
 
   scene->SetAmbientLight(0.3, 0.3, 0.3);
-  scene->SetNumCameraPassesPerGpuFlush(6u);
+  scene->SetCameraPassCountPerGpuFlush(6u);
 
   // Create a sensor manager
   ignition::sensors::Manager mgr;


### PR DESCRIPTION
# 🎉 New feature

See ignitionrobotics/ign-rendering/issues/323

## Summary

ign-rendering has a new feature aimed to improve performance but also fixes a few bugs related to particle simulations; which is controlled via `Scene::SetCameraPassCountPerGpuFlush`.

A value of 0 will use the legacy mode (i.e. previous behavior) to ease porting from older version.
A value > 0 controls performance vs RAM tradeoff (note that it is an upper limit; a very high value doesn't immediately waste RAM. See `Scene::SetCameraPassCountPerGpuFlush` documentation for details)

These changes makes sensors aware of legacy and new setting so that it adapts to both modes of operation.

This PR depends on https://github.com/ignitionrobotics/ign-rendering/pull/353 **otherwise it will not compile**.

## Test it

Just run the code again. This PR changes SetCameraPassCountPerGpuFlush in tests explicitly to 6 to take advantage of the new feature. Set it to 0 for legacy.

Outside of tests, this PR will not change CameraPassCountPerGpuFlush (since it has to respect what the user selects); thus the default value of Ogre2ScenePrivate::cameraPassCountPerGpuFlush matters.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
