### PR TITLE
Publish performance sensor metrics.

### DIFF
--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -191,10 +191,8 @@ namespace ignition
 
       /// \brief Publishes information about the performance of the sensor.
       ///        This method is called by Update().
-      ///        When different metrics need to be published this method
-      ///        could be overriden by subclasses.
       /// \param[in] _now Current time.
-      public: virtual void PublishMetrics(
+      public: void PublishMetrics(
         const std::chrono::duration<double> &_now);
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -184,7 +184,7 @@ namespace ignition
       ///        This method is called by Update().
       ///        When different metrics need to be published this method
       ///        could be overriden by subclasses.
-      /// \param[in] _simTime Current time.
+      /// \param[in] _now Current time.
       public: virtual void PublishMetrics(const ignition::common::Time &_now);
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -180,6 +180,13 @@ namespace ignition
       public: void AddSequence(ignition::msgs::Header *_msg,
                   const std::string &_seqKey = "default");
 
+      /// \brief Publishes information about the performance of the sensor.
+      ///        This method is called by Update().
+      ///        When different metrics need to be published this method
+      ///        could be overriden by subclasses.
+      /// \param[in] _simTime Current time.
+      public: virtual void PublishMetrics(const ignition::common::Time &_now);
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \internal
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -147,6 +147,14 @@ namespace ignition
       /// \return True if a valid topic was set.
       public: bool SetTopic(const std::string &_topic);
 
+      /// \brief Get flag state for enabling performance metrics publication.
+      /// \return True if performance metrics are enabled, false otherwise.
+      public: bool EnableMetrics() const;
+
+      /// \brief Set flag to enable publishing performance metrics
+      /// \param[in] _enableMetrics True to enable.
+      public: void SetEnableMetrics(bool _enableMetrics);
+
       /// \brief Get parent link of the sensor.
       /// \return Parent link of sensor.
       public: std::string Parent() const;

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -27,6 +27,7 @@
 #pragma warning(pop)
 #endif
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -185,7 +186,8 @@ namespace ignition
       ///        When different metrics need to be published this method
       ///        could be overriden by subclasses.
       /// \param[in] _now Current time.
-      public: virtual void PublishMetrics(const ignition::common::Time &_now);
+      public: virtual void PublishMetrics(
+        const std::chrono::duration<double> &_now);
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \internal

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -60,6 +60,9 @@ class ignition::sensors::SensorPrivate
   /// \brief Pose of the sensor
   public: ignition::math::Pose3d pose;
 
+  /// \brief Flag to enable publishing performance metrics.
+  public: bool enableMetrics{false};
+
   /// \brief How many times the sensor will generate data per second
   public: double updateRate = 0.0;
 
@@ -127,6 +130,8 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
   }
 
   this->updateRate = _sdf.UpdateRate();
+
+  this->enableMetrics = _sdf.EnableMetrics();
   return true;
 }
 
@@ -211,6 +216,19 @@ bool SensorPrivate::SetTopic(const std::string &_topic)
 
   this->topic = validTopic;
   return true;
+}
+
+//////////////////////////////////////////////////
+bool Sensor::EnableMetrics() const
+{
+  return this->dataPtr->enableMetrics;
+}
+
+
+//////////////////////////////////////////////////
+void Sensor::SetEnableMetrics(bool _enableMetrics)
+{
+  this->dataPtr->enableMetrics = _enableMetrics;
 }
 
 //////////////////////////////////////////////////
@@ -334,7 +352,10 @@ bool Sensor::Update(const ignition::common::Time &_now,
   result = this->Update(_now);
 
   // Publish metrics
-  this->PublishMetrics(std::chrono::duration<double>(_now.Double()));
+  if (this->EnableMetrics())
+  {
+    this->PublishMetrics(std::chrono::duration<double>(_now.Double()));
+  }
 
   if (!_force && this->dataPtr->updateRate > 0.0)
   {

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -40,7 +40,7 @@ class ignition::sensors::SensorPrivate
 
   /// \brief Publishes information about the performance of the sensor.
   /// \param[in] _now Current simulation time.
-  public: void PublishMetrics(const ignition::common::Time& _now);
+  public: void PublishMetrics(const ignition::common::Time &_now);
 
   /// \brief id given to sensor when constructed
   public: SensorId id;
@@ -219,7 +219,8 @@ void Sensor::PublishMetrics(const ignition::common::Time &_now)
   return this->dataPtr->PublishMetrics(_now);
 }
 
-void SensorPrivate::PublishMetrics(const ignition::common::Time &_now) {
+void SensorPrivate::PublishMetrics(const ignition::common::Time &_now)
+{
   if(!this->performanceSensorMetricsPub)
   {
     this->performanceSensorMetricsPub =

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -162,6 +162,8 @@ class SensorUpdate : public ::testing::Test
   protected: const std::string kSensorName{"sensor_test"};
   // Sensor topic.
   protected: const std::string kSensorTopic{"/sensor_test"};
+  // Enable metrics flag.
+  protected: const bool kEnableMetrics{true};
   // Topic where performance metrics are published.
   protected: const std::string kPerformanceMetricTopic{
     kSensorTopic + "/performance_metrics"};
@@ -180,9 +182,11 @@ TEST_F(SensorUpdate, Update)
   sdf::Sensor sdfSensor;
   sdfSensor.SetName(kSensorName);
   sdfSensor.SetTopic(kSensorTopic);
+  sdfSensor.SetEnableMetrics(kEnableMetrics);
   std::unique_ptr<Sensor> sensor = std::make_unique<TestSensor>();
   sensor->Load(sdfSensor);
   ASSERT_EQ(kSensorTopic, sensor->Topic());
+  ASSERT_EQ(kEnableMetrics, sensor->EnableMetrics());
 
   // Call Update() method kNumberOfMessages times.
   // For each call there is also a call to Sensor::PublishMetrics() that

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -14,11 +14,27 @@
  * limitations under the License.
  *
 */
+#include <ignition/sensors/Sensor.hh>
+
+#include <atomic>
+#include <memory>
+
 #include <gtest/gtest.h>
 
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/msgs/performance_sensor_metrics.pb.h>
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
+
 #include <ignition/common/Console.hh>
+#include <ignition/common/Time.hh>
 #include <ignition/sensors/Export.hh>
-#include <ignition/sensors/Sensor.hh>
+#include <ignition/transport/Node.hh>
 
 using namespace ignition;
 using namespace sensors;
@@ -122,6 +138,72 @@ TEST(Sensor_TEST, Topic)
   EXPECT_EQ("/topic_with_spaces/characters", sensor.Topic());
 
   EXPECT_FALSE(sensor.SetTopic(""));
+}
+
+class SensorUpdate : public ::testing::Test
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+    node.Subscribe(kPerformanceMetricTopic,
+      &SensorUpdate::OnPerformanceMetric, this);
+  }
+
+  // Callback function for the performance metric topic.
+  protected: void OnPerformanceMetric(
+    const ignition::msgs::PerformanceSensorMetrics &_msg)
+  {
+    EXPECT_EQ(kSensorName, _msg.name());
+    performanceMetricsMsgsCount++;
+  }
+
+  // Sensor name.
+  protected: const std::string kSensorName{"sensor_test"};
+  // Sensor topic.
+  protected: const std::string kSensorTopic{"/sensor_test"};
+  // Topic where performance metrics are published.
+  protected: const std::string kPerformanceMetricTopic{
+    kSensorTopic + "/performance_metrics"};
+  // Number of messages to be published.
+  protected: const unsigned int kNumberOfMessages{10};
+  // Counter for performance metrics messages published.
+  protected: std::atomic<unsigned int> performanceMetricsMsgsCount{0};
+  // Transport node.
+  protected: transport::Node node;
+};
+
+//////////////////////////////////////////////////
+TEST_F(SensorUpdate, Update)
+{
+  // Create sensor.
+  sdf::Sensor sdfSensor;
+  sdfSensor.SetName(kSensorName);
+  sdfSensor.SetTopic(kSensorTopic);
+  std::unique_ptr<Sensor> sensor = std::make_unique<TestSensor>();
+  sensor->Load(sdfSensor);
+  ASSERT_EQ(kSensorTopic, sensor->Topic());
+
+  // Call Update() method kNumberOfMessages times.
+  // For each call there is also a call to Sensor::PublishMetrics() that
+  // publishes metrics in the correspondant topic.
+  for (int sec = 0 ; sec < static_cast<int>(kNumberOfMessages) ; ++sec)
+  {
+    common::Time now{sec, 0 /*nsec*/};
+    sensor->Update(now, true);
+  }
+
+  int sleep = 0;
+  const int maxSleep = 30;
+  while (performanceMetricsMsgsCount < kNumberOfMessages && sleep < maxSleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    sleep++;
+  }
+  ASSERT_EQ(kNumberOfMessages, performanceMetricsMsgsCount);
+
+  auto testSensor = dynamic_cast<TestSensor*>(sensor.get());
+  EXPECT_EQ(testSensor->updateCount, performanceMetricsMsgsCount);
 }
 
 //////////////////////////////////////////////////

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -183,7 +183,7 @@ TEST_F(SensorUpdate, Update)
   sdfSensor.SetName(kSensorName);
   sdfSensor.SetTopic(kSensorTopic);
   sdfSensor.SetEnableMetrics(kEnableMetrics);
-  std::unique_ptr<Sensor> sensor = std::make_unique<TestSensor>();
+  std::unique_ptr<TestSensor> sensor = std::make_unique<TestSensor>();
   sensor->Load(sdfSensor);
   ASSERT_EQ(kSensorTopic, sensor->Topic());
   ASSERT_EQ(kEnableMetrics, sensor->EnableMetrics());
@@ -206,7 +206,6 @@ TEST_F(SensorUpdate, Update)
   }
   ASSERT_EQ(kNumberOfMessages, performanceMetricsMsgsCount);
 
-  auto testSensor = dynamic_cast<TestSensor*>(sensor.get());
   EXPECT_EQ(testSensor->updateCount, performanceMetricsMsgsCount);
 }
 

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -183,7 +183,7 @@ TEST_F(SensorUpdate, Update)
   sdfSensor.SetName(kSensorName);
   sdfSensor.SetTopic(kSensorTopic);
   sdfSensor.SetEnableMetrics(kEnableMetrics);
-  std::unique_ptr<TestSensor> sensor = std::make_unique<TestSensor>();
+  std::unique_ptr<Sensor> sensor = std::make_unique<TestSensor>();
   sensor->Load(sdfSensor);
   ASSERT_EQ(kSensorTopic, sensor->Topic());
   ASSERT_EQ(kEnableMetrics, sensor->EnableMetrics());
@@ -206,6 +206,7 @@ TEST_F(SensorUpdate, Update)
   }
   ASSERT_EQ(kNumberOfMessages, performanceMetricsMsgsCount);
 
+  auto testSensor = dynamic_cast<TestSensor*>(sensor.get());
   EXPECT_EQ(testSensor->updateCount, performanceMetricsMsgsCount);
 }
 


### PR DESCRIPTION
Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>

# 🎉 New feature

Related to https://github.com/ignitionrobotics/ign-gazebo/issues/557

## Summary

- `ignition::sensors::Sensor` publishes a performance metric message (`ignition::msgs::PeformanceSensorMetrics`)
for each Update() call. The message is published at `<sensor_topic_name>/performance_metrics`
   -  This message is being added to the `ignition-msgs` in PR: https://github.com/ignitionrobotics/ign-msgs/pull/172
- Publishing performance metrics can be disabled trough sdf: https://github.com/ignitionrobotics/sdformat/pull/665   
```proto
message PerformanceSensorMetrics
{
  /// \brief Sensor name
  string name                 = 1;

  /// \brief The update rate of the sensor in real time.
  double real_update_rate     = 2;

  /// \brief The update rate of the sensor in simulation time.
  double sim_update_rate      = 3;

  /// \brief The nominal update rate defined to the sensor.
  double nominal_update_rate  = 4;

  /// \brief If the sensor is a camera then this field should be filled
  /// with average fps in real time.
  Double fps                  = 5;
}
```

- `ignition::sensors::Sensor` provides an API to let the subclasses to publish a custom message or change the way the metrics are computed. For example, `CameraSensor`'s `PublishMetrics` implementation should also fill the `fps` field of the message.



## Test it
It can be tested using an ignition simulation:

the sensors in the `.sdf` must enable this behavior by doing:
`<enable_metrics>true</enable_metrics>`

Then we can do:

```sh
ign gazebo sensors.sdf
```
and then verify the messages being published:
```
ign topic --list
```

```
/air_pressure
/air_pressure/performance_metrics
/altimeter
/altimeter/performance_metrics
/clock
/gazebo/resource_paths
/gui/camera/pose
/gui/record_video/stats
/imu
/imu/performance_metrics
/magnetometer
/magnetometer/performance_metrics
...

```


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

