### PR TITLE
👩‍🌾 Print debug messages when sensors advertise topics

### DIFF
--- a/src/AirPressureSensor.cc
+++ b/src/AirPressureSensor.cc
@@ -122,6 +122,9 @@ bool AirPressureSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "Air pressure for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
   // Load the noise parameters
   if (_sdf.AirPressureSensor()->PressureNoise().Type() != sdf::NoiseType::NONE)
   {

--- a/src/AltimeterSensor.cc
+++ b/src/AltimeterSensor.cc
@@ -100,6 +100,9 @@ bool AltimeterSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "Altimeter data for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
   // Load the noise parameters
   if (_sdf.AltimeterSensor()->VerticalPositionNoise().Type()
       != sdf::NoiseType::NONE)

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -267,6 +267,9 @@ bool CameraSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "Camera images for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
   if (!this->AdvertiseInfo())
     return false;
 
@@ -500,16 +503,7 @@ bool CameraSensor::AdvertiseInfo()
   }
   this->dataPtr->infoTopic += "/camera_info";
 
-  this->dataPtr->infoPub =
-      this->dataPtr->node.Advertise<ignition::msgs::CameraInfo>(
-      this->dataPtr->infoTopic);
-  if (!this->dataPtr->infoPub)
-  {
-    ignerr << "Unable to create publisher on topic["
-      << this->dataPtr->infoTopic << "].\n";
-  }
-
-  return this->dataPtr->infoPub;
+  return this->AdvertiseInfo(this->dataPtr->infoTopic);
 }
 
 //////////////////////////////////////////////////
@@ -524,6 +518,11 @@ bool CameraSensor::AdvertiseInfo(const std::string &_topic)
   {
     ignerr << "Unable to create publisher on topic["
       << this->dataPtr->infoTopic << "].\n";
+  }
+  else
+  {
+    igndbg << "Camera info advertised on [" << this->dataPtr->infoTopic << "]"
+           << std::endl;
   }
 
   return this->dataPtr->infoPub;

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -284,6 +284,9 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "Depth images for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
   if (!this->AdvertiseInfo())
     return false;
 
@@ -297,6 +300,9 @@ bool DepthCameraSensor::Load(const sdf::Sensor &_sdf)
       << this->Topic() + "/points" << "].\n";
     return false;
   }
+
+  igndbg << "Points for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
 
   // Initialize the point message.
   // \todo(anyone) The true value in the following function call forces

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -146,6 +146,9 @@ bool GpuLidarSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "Lidar points for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
   this->initialized = true;
 
   return true;

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -124,6 +124,9 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "IMU data for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
   const std::map<SensorNoiseType, sdf::Noise> noises = {
     {ACCELEROMETER_X_NOISE_M_S_S, _sdf.ImuSensor()->LinearAccelerationXNoise()},
     {ACCELEROMETER_Y_NOISE_M_S_S, _sdf.ImuSensor()->LinearAccelerationYNoise()},

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -118,7 +118,9 @@ bool Lidar::Load(const sdf::Sensor &_sdf)
       << this->Topic() << "].\n";
     return false;
   }
-  ignmsg << "Publishing laser scans on [" << this->Topic() << "]" << std::endl;
+
+  igndbg << "Laser scans for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
 
   // Load ray atributes
   this->dataPtr->sdfLidar = *_sdf.LidarSensor();

--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -117,6 +117,9 @@ bool LogicalCameraSensor::Load(sdf::ElementPtr _sdf)
     return false;
   }
 
+  igndbg << "Logical images for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
   this->dataPtr->initialized = true;
   return true;
 }

--- a/src/MagnetometerSensor.cc
+++ b/src/MagnetometerSensor.cc
@@ -114,6 +114,9 @@ bool MagnetometerSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "Magnetometer data for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
   // Load the noise parameters
   if (_sdf.MagnetometerSensor()->XNoise().Type() != sdf::NoiseType::NONE)
   {

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -211,6 +211,9 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "RGB images for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "/image]" << std::endl;
+
   // Create the depth image publisher
   this->dataPtr->depthPub =
       this->dataPtr->node.Advertise<ignition::msgs::Image>(
@@ -222,6 +225,9 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "Depth images for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "/depth_image]" << std::endl;
+
   // Create the point cloud publisher
   this->dataPtr->pointPub =
       this->dataPtr->node.Advertise<ignition::msgs::PointCloudPacked>(
@@ -232,6 +238,9 @@ bool RgbdCameraSensor::Load(const sdf::Sensor &_sdf)
       << this->Topic() + "/points" << "].\n";
     return false;
   }
+
+  igndbg << "Points for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "/points]" << std::endl;
 
   if (!this->AdvertiseInfo(this->Topic() + "/camera_info"))
     return false;

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -214,6 +214,9 @@ bool ThermalCameraSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  igndbg << "Thermal images for [" << this->Name() << "] advertised on ["
+         << this->Topic() << "]" << std::endl;
+
   if (!this->AdvertiseInfo())
     return false;
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

I've been trying to debug Gazebo test failures, and having these messages printed should help.

I thought of using `ignmsg`, but was afraid that it may become spammy on worlds with many sensors.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Load `ign-gazebo` with maximum verbosity (`-v 4`), or run some tests in this repo.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

https://github.com/osrf/buildfarmer/issues/224