### PR TITLE
Trivial tutorial typo correction

### DIFF
--- a/tutorials/custom_sensors.md
+++ b/tutorials/custom_sensors.md
@@ -25,9 +25,9 @@ implement proprietary sensors that can't be shared publicly.
 A simulated sensor consists of code that can be used to extract specific data
 from a running simulation. A camera extracts pixels, an IMU extracts
 accelerations, etc. This doesn't necessarily need to be done though Ignition
-Sensors. On Ignition Gazebo, for example, it's implement functionality similar
-to a sensor just using a system plugin without any connection to Ignition
-Sensors.
+Sensors. On Ignition Gazebo, for example, it's possible to implement
+functionality similar to a sensor just using a system plugin without any
+connection to Ignition Sensors.
 
 With that in mind, it's worth going over some of the features that Ignition
 Sensors provides that make it easier to implement sensors, instead of writing


### PR DESCRIPTION
# 🦟 Bug fix

Caught a typo while reading the tutorial. Literally just this change: "It's implement" -> "It's possible to implement"

## Checklist
- [x] Signed all commits for DCO
- [ ] ~~Added tests~~
- [x] Updated documentation (as needed)
- [ ] ~~Updated migration guide (as needed)~~
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
