### PR TITLE
Destroy rendering sensors when sensor is removed

### DIFF
--- a/src/RenderingSensor.cc
+++ b/src/RenderingSensor.cc
@@ -56,6 +56,15 @@ RenderingSensor::RenderingSensor() :
 //////////////////////////////////////////////////
 RenderingSensor::~RenderingSensor()
 {
+  if (!this->dataPtr->scene)
+    return;
+  for (auto &s : this->dataPtr->sensors)
+  {
+    auto sensor = s.lock();
+    if (sensor)
+      this->dataPtr->scene->DestroySensor(sensor);
+  }
+  this->dataPtr->sensors.clear();
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -109,6 +109,18 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
 
   EXPECT_TRUE(helper.WaitForMessage()) << helper;
 
+  // test removing sensor
+  // first make sure the sensor objects do exist
+  auto sensorId = sensor->Id();
+  auto cameraId = sensor->RenderingCamera()->Id();
+  EXPECT_EQ(sensor, mgr.Sensor(sensorId));
+  EXPECT_EQ(sensor->RenderingCamera(), scene->SensorById(cameraId));
+  // remove and check sensor objects no longer exist in both sensors and
+  // rendering
+  EXPECT_TRUE(mgr.Remove(sensorId));
+  EXPECT_EQ(nullptr, mgr.Sensor(sensorId));
+  EXPECT_EQ(nullptr, scene->SensorById(cameraId));
+
   // Clean up
   engine->DestroyScene(scene);
   ignition::rendering::unloadEngine(engine->Name());


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

related to https://github.com/ignitionrobotics/ign-gazebo/pull/1170

## Summary

Currently when a rendering sensor is removed, the objects in ign-rendering are not destroyed. This PR adds calls to destroy the rendering sensors. Otherwise when a new sensor is created with the same name, ign-rendering will complain that the sensor already exists.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

