### PR TITLE
IMU ``custom_rpy``  tag parsing added

### DIFF
--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -117,10 +117,12 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
   }
 
   // Set orientation reference frame
-  // TODO(adityapande-1995) : Add support for named frames like ENU using ign-gazebo
+  // TODO(adityapande-1995) : Add support for named frames like
+  // ENU using ign-gazebo
   if (_sdf.ImuSensor()->Localization() == "CUSTOM") {
     if (_sdf.ImuSensor()->CustomRpyParentFrame() == "") {
-      this->SetOrientationReference(ignition::math::Quaterniond(_sdf.ImuSensor()->CustomRpy()));
+      this->SetOrientationReference(ignition::math::Quaterniond(
+        _sdf.ImuSensor()->CustomRpy()));
     }
   } else {
     ignerr << "This tag is not yet supported" << std::endl;

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -117,7 +117,7 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
   }
 
   // Set orientation reference frame
-  // TODO : Add support for named frames like ENU using ign-gazebo
+  // TODO(adityapande-1995) : Add support for named frames like ENU using ign-gazebo
   if (_sdf.ImuSensor()->Localization() == "CUSTOM") {
     if (_sdf.ImuSensor()->CustomRpyParentFrame() == "") {
       this->SetOrientationReference(ignition::math::Quaterniond(_sdf.ImuSensor()->CustomRpy()));

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -116,6 +116,16 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
+  // Set orientation reference frame
+  // TODO : Add support for named frames like ENU using ign-gazebo
+  if (_sdf.ImuSensor()->Localization() == "CUSTOM") {
+    if (_sdf.ImuSensor()->CustomRpyParentFrame() == "") {
+      this->SetOrientationReference(ignition::math::Quaterniond(_sdf.ImuSensor()->CustomRpy()));
+    }
+  } else {
+    ignerr << "This tag is not yet supported" << std::endl;
+  }
+
   if (this->Topic().empty())
     this->SetTopic("/imu");
 

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -119,13 +119,19 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
   // Set orientation reference frame
   // TODO(adityapande-1995) : Add support for named frames like
   // ENU using ign-gazebo
-  if (_sdf.ImuSensor()->Localization() == "CUSTOM") {
-    if (_sdf.ImuSensor()->CustomRpyParentFrame() == "") {
+  if (_sdf.ImuSensor()->Localization() == "CUSTOM")
+  {
+    if (_sdf.ImuSensor()->CustomRpyParentFrame() == "")
+    {
       this->SetOrientationReference(ignition::math::Quaterniond(
         _sdf.ImuSensor()->CustomRpy()));
     }
-  } else {
-    ignerr << "This tag is not yet supported" << std::endl;
+    else
+    {
+      ignerr << "custom_rpy parent frame must be set to empty "
+	      "string. Setting it to any other frame is not "
+	      "supported yet." << std::endl;
+    }
   }
 
   if (this->Topic().empty())

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -128,9 +128,9 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
     }
     else
     {
-      ignerr << "custom_rpy parent frame must be set to empty "
-	      "string. Setting it to any other frame is not "
-	      "supported yet." << std::endl;
+      ignwarn << "custom_rpy parent frame must be set to empty "
+		"string. Setting it to any other frame is not "
+		"supported yet." << std::endl;
     }
   }
 

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -129,8 +129,8 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
     else
     {
       ignwarn << "custom_rpy parent frame must be set to empty "
-		"string. Setting it to any other frame is not "
-		"supported yet." << std::endl;
+                "string. Setting it to any other frame is not "
+                "supported yet." << std::endl;
     }
   }
 

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -422,9 +422,12 @@ TEST(ImuSensor_TEST, OrientationReference)
 
   sdf::SDFPtr sdfParsed(new sdf::SDF());
   sdf::init(sdfParsed);
-  if (!sdf::readString(stream.str(), sdfParsed)) {
+  if (!sdf::readString(stream.str(), sdfParsed))
+  {
     imuSDF = sdf::ElementPtr();
-  } else {
+  }
+  else
+  {
     imuSDF = sdfParsed->Root()->GetElement("model")->GetElement("link")
       ->GetElement("sensor");
   }
@@ -442,6 +445,69 @@ TEST(ImuSensor_TEST, OrientationReference)
   math::Quaterniond orientValue(math::Vector3d(-1.570795, 0, 0));
   EXPECT_EQ(orientValue, sensor->Orientation());
 
+}
+
+//////////////////////////////////////////////////
+TEST(ImuSensor_TEST, CustomRpyParentFrame)
+{
+  // Create a sensor manager
+  ignition::sensors::Manager mgr;
+
+  sdf::ElementPtr imuSDF;
+
+  std::ostringstream stream;
+  stream
+    << "<?xml version='1.0'?>"
+    << "<sdf version='1.6'>"
+    << " <model name='m1'>"
+    << "  <link name='link1'>"
+    << "    <sensor name='imu_sensor' type='imu'>"
+    << "      <topic>imu_test</topic>"
+    << "      <update_rate>1</update_rate>"
+    << "      <imu>"
+    << "      <orientation_reference_frame>"
+    << "      <localization>CUSTOM</localization>"
+    << "      <custom_rpy parent_frame='some_frame'>"
+    << "      1.570795 0 0"
+    << "      </custom_rpy>"
+    << "      </orientation_reference_frame>"
+    << "      </imu>"
+    << "      <always_on>1</always_on>"
+    << "      <visualize>true</visualize>"
+    << "    </sensor>"
+    << "  </link>"
+    << " </model>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  if (!sdf::readString(stream.str(), sdfParsed))
+  {
+    imuSDF = sdf::ElementPtr();
+  }
+  else
+  {
+    imuSDF = sdfParsed->Root()->GetElement("model")->GetElement("link")
+      ->GetElement("sensor");
+  }
+
+  // Create an ImuSensor
+  auto sensor = mgr.CreateSensor<ignition::sensors::ImuSensor>(
+      imuSDF);
+
+  // Make sure the above dynamic cast worked.
+  ASSERT_NE(nullptr, sensor);
+
+  sensor->Update(std::chrono::steady_clock::duration(
+    std::chrono::nanoseconds(10000000)));
+
+  // Since parent_frame is not set to empty in the sdf,
+  // custom_rpy will be rejected and reference orientation will
+  // not be set.
+  math::Quaterniond orientValue(math::Vector3d(-1.570795, 0, 0));
+  math::Quaterniond defultOrientValue(math::Vector3d(0, 0, 0));
+  ASSERT_NE(orientValue, sensor->Orientation());
+  EXPECT_EQ(defultOrientValue, sensor->Orientation());
 }
 
 //////////////////////////////////////////////////

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -391,6 +391,60 @@ TEST(ImuSensor_TEST, Orientation)
 }
 
 //////////////////////////////////////////////////
+TEST(ImuSensor_TEST, OrientationReference)
+{
+  // Create a sensor manager
+  ignition::sensors::Manager mgr;
+
+  sdf::ElementPtr imuSDF;
+
+  std::ostringstream stream;
+  stream
+    << "<?xml version='1.0'?>"
+    << "<sdf version='1.6'>"
+    << " <model name='m1'>"
+    << "  <link name='link1'>"
+    << "    <sensor name='imu_sensor' type='imu'>"
+    << "      <topic>imu_test</topic>"
+    << "      <update_rate>1</update_rate>"
+    << "      <imu>"
+    << "      <orientation_reference_frame>"
+    << "      <localization>CUSTOM</localization>"
+    << "      <custom_rpy>1.570795 0 0</custom_rpy>"
+    << "      </orientation_reference_frame>"
+    << "      </imu>"
+    << "      <always_on>1</always_on>"
+    << "      <visualize>true</visualize>"
+    << "    </sensor>"
+    << "  </link>"
+    << " </model>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  if (!sdf::readString(stream.str(), sdfParsed)) {
+    std::cout << "Debug 1" << std::endl;
+  }
+
+  imuSDF = sdfParsed->Root()->GetElement("model")->GetElement("link")
+    ->GetElement("sensor");
+
+  // Create an ImuSensor
+  auto sensor = mgr.CreateSensor<ignition::sensors::ImuSensor>(
+      imuSDF);
+
+  // Make sure the above dynamic cast worked.
+  ASSERT_NE(nullptr, sensor);
+
+  sensor->Update(std::chrono::steady_clock::duration(
+    std::chrono::nanoseconds(10000000)));
+
+  math::Quaterniond orientValue(math::Vector3d(-1.570795, 0, 0));
+  EXPECT_EQ(orientValue, sensor->Orientation());
+
+}
+
+//////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -28,6 +28,7 @@
 #pragma warning(pop)
 #endif
 
+#include <ignition/common/Console.hh>
 #include <ignition/sensors/Export.hh>
 #include <ignition/sensors/ImuSensor.hh>
 #include <ignition/sensors/Manager.hh>
@@ -187,7 +188,7 @@ class ImuSensor_TEST : public ::testing::Test
   // Documentation inherited
   protected: void SetUp() override
   {
-    ignition::common::Console::SetVerbosity(4);
+    ignition::common::Console::SetVerbosity(3);
   }
 };
 

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -422,9 +422,12 @@ TEST(ImuSensor_TEST, OrientationReference)
 
   sdf::SDFPtr sdfParsed(new sdf::SDF());
   sdf::init(sdfParsed);
-
-  imuSDF = sdfParsed->Root()->GetElement("model")->GetElement("link")
-    ->GetElement("sensor");
+  if (!sdf::readString(stream.str(), sdfParsed)) {
+    imuSDF = sdf::ElementPtr();
+  } else {
+    imuSDF = sdfParsed->Root()->GetElement("model")->GetElement("link")
+      ->GetElement("sensor");
+  }
 
   // Create an ImuSensor
   auto sensor = mgr.CreateSensor<ignition::sensors::ImuSensor>(

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -422,9 +422,6 @@ TEST(ImuSensor_TEST, OrientationReference)
 
   sdf::SDFPtr sdfParsed(new sdf::SDF());
   sdf::init(sdfParsed);
-  if (!sdf::readString(stream.str(), sdfParsed)) {
-    std::cout << "Debug 1" << std::endl;
-  }
 
   imuSDF = sdfParsed->Root()->GetElement("model")->GetElement("link")
     ->GetElement("sensor");


### PR DESCRIPTION
Signed-off-by: Aditya <aditya050995@gmail.com>

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

Closes https://github.com/ignitionrobotics/ign-sensors/issues/174

## Summary
According to REP 145, an IMU can report orientation with respect to the world, or some given reference frame. The method SetOrientationReference enables this, but this cannot be set via sdf currently.
The ``orientation_reference_frame`` tag ( http://sdformat.org/spec?ver=1.9&elem=sensor#imu_orientation_reference_frame) exposes this, but it is ignored currently in the ``Load`` method for the IMU sensor. This PR aims to set reference orientation when the ``localization`` tag is set to ``CUSTOM`` and ``custom_rpy`` is set to some non zero angles. 

## Test it
I've added a test case, but if one wants to run it independently, you can use the following sdf snippet : 
```
<?xml version='1.0'?>
<sdf version='1.6'>
 <model name='m1'>
  <link name='link1'>
    <sensor name='imu_sensor' type='imu'>
      <topic>imu_test</topic>
      <update_rate>1</update_rate>
      <imu>
      <orientation_reference_frame>
      <localization>CUSTOM</localization>
      <custom_rpy>1.570795 0 0</custom_rpy>
      </orientation_reference_frame>
      </imu>
      <always_on>1</always_on>
      <visualize>true</visualize>
    </sensor>
  </link>
 </model>
</sdf>
```

After first update, if the IMU orientation is (0 0 0) by default, it should be now (-1.570795 0 0) as the reference axis has been modified in the sdf.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

