### PR TITLE
Added Logic to flag pointcloud if invalid point is Detected

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,12 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Sensors 6.0.1 to 6.X.X
+
+### Modifications
+1. Point Cloud Density flag (**is_dense** from GpuLidarSensor) is set to **false** if invalid points (NaN or +/-INF) are found, and **true** otherwise.
+
+
 ## Ignition Sensors 5.X to 6.X
 
 1. Sensors aren't loaded as plugins anymore. Instead, downstream libraries must

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -338,7 +338,7 @@ void GpuLidarSensorPrivate::FillPointCloudMsg(const float *_laserBuffer)
       auto index = j * width * channels + i * channels;
       float depth = _laserBuffer[index];
       // Validate Depth/Radius and update pointcloud density flag
-      if(isDense)
+      if (isDense)
         isDense = !(ignition::math::isnan(depth) || std::isinf(depth));
 
       float intensity = _laserBuffer[index + 1];

--- a/src/GpuLidarSensor.cc
+++ b/src/GpuLidarSensor.cc
@@ -337,10 +337,10 @@ void GpuLidarSensorPrivate::FillPointCloudMsg(const float *_laserBuffer)
       // Index of current point, and the depth value at that point
       auto index = j * width * channels + i * channels;
       float depth = _laserBuffer[index];
-      // Validate Depth/Radius and update pointcloud density flag      
-      if(isDense) 
+      // Validate Depth/Radius and update pointcloud density flag
+      if(isDense)
         isDense = !(ignition::math::isnan(depth) || std::isinf(depth));
-      //
+
       float intensity = _laserBuffer[index + 1];
       uint16_t ring = j;
 

--- a/test/integration/gpu_lidar_sensor.cc
+++ b/test/integration/gpu_lidar_sensor.cc
@@ -411,7 +411,7 @@ void GpuLidarSensorTest::DetectBox(const std::string &_renderEngine)
   EXPECT_FALSE(pointMsgs.back().is_bigendian());
   EXPECT_EQ(32u, pointMsgs.back().point_step());
   EXPECT_EQ(32u * horzSamples, pointMsgs.back().row_step());
-  EXPECT_TRUE(pointMsgs.back().is_dense());
+  EXPECT_FALSE(pointMsgs.back().is_dense());
   EXPECT_EQ(32u * horzSamples * vertSamples, pointMsgs.back().data().size());
 
   // Clean up


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #179 

## Summary
Currently, when filling pointcloud message, the is_dense field is always set to true. According to the definition used by [PCL](https://pointclouds.org/documentation/singletonpcl_1_1_point_cloud.html#a3ca88d8ebf6f4f35acbc31cdfb38aa94), a pointcloud should be considered dense if all point are valid  (i.e. not NaN nor +/-INF). Please refer to the linked issue to understand the common problem that this can cause when using PCL lib.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.