### PR TITLE
IMU sensor API to get world ref frame and heading offset 

### DIFF
--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -36,6 +36,16 @@ namespace ignition
     // Inline bracket to help doxygen filtering.
     inline namespace IGNITION_SENSORS_VERSION_NAMESPACE {
     //
+    // \brief Reference frames enum
+    enum class IGNITION_SENSORS_VISIBLE WorldFrameEnumType
+    {
+      NONE = 0,
+      ENU = 1,
+      NED = 2,
+      NWU = 3
+    };
+
+    //
     /// \brief forward declarations
     class ImuSensorPrivate;
 
@@ -136,11 +146,12 @@ namespace ignition
       /// \return Gravity vectory in meters per second squared.
       public: math::Vector3d Gravity() const;
       
-      /// \brief Convey worl frame's orientation and heading offset
-      /// \param[in] _rot heading offset
-      /// \param[in] _relativeTo world frame orintation, "ENU" by default
+      /// \brief Specify the rotation offset of the coordinates of the World
+      //  frame relative to a geo-referenced frame
+      /// \param[in] _rot rotation offset
+      /// \param[in] _relativeTo world frame orintation, ENU by default
       public: void SetWorldFrameOrientation(
-        const math::Quaterniond &_rot, std::string _relativeTo);
+        const math::Quaterniond &_rot, WorldFrameEnumType _relativeTo);
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -35,8 +35,14 @@ namespace ignition
   {
     // Inline bracket to help doxygen filtering.
     inline namespace IGNITION_SENSORS_VERSION_NAMESPACE {
-    //
+
     // \brief Reference frames enum
+    // NONE : To be used only when <localization>
+    // reference orintation tag is empty.
+    // ENU (East-North-Up): x - East, y - North, z - Up.
+    // NED (North-East-Down): x - North, y - East, z - Down.
+    // NWU (North-West-Up): x - North, y - West, z - Up.
+    // CUSTOM : The frame is described using custom_rpy tag.
     enum class IGNITION_SENSORS_VISIBLE WorldFrameEnumType
     {
       NONE = 0,

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -135,6 +135,12 @@ namespace ignition
       /// \brief Get the gravity vector
       /// \return Gravity vectory in meters per second squared.
       public: math::Vector3d Gravity() const;
+      
+      /// \brief Convey worl frame's orientation and heading offset
+      /// \param[in] _rot heading offset
+      /// \param[in] _relativeTo world frame orintation, "ENU" by default
+      public: void SetWorldFrameOrientation(
+        const math::Quaterniond &_rot, std::string _relativeTo);
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -145,7 +145,7 @@ namespace ignition
       /// \brief Get the gravity vector
       /// \return Gravity vectory in meters per second squared.
       public: math::Vector3d Gravity() const;
-      
+
       /// \brief Specify the rotation offset of the coordinates of the World
       //  frame relative to a geo-referenced frame
       /// \param[in] _rot rotation offset

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -154,6 +154,14 @@ namespace ignition
       public: void SetWorldFrameOrientation(
         const math::Quaterniond &_rot, WorldFrameEnumType _relativeTo);
 
+      // \brief Read the localization sdf tag
+      // \param[in] _sdf Imu sdf data as sdf::Sensor
+      public: void ReadLocalizationTag(const sdf::Sensor &_sdf);
+
+      // \brief Read the localization sdf tag
+      // \param[in] _sdf Imu sdf data as sdf:;ElementPtr
+      public: void ReadLocalizationTag(sdf::ElementPtr _sdf);
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -37,18 +37,22 @@ namespace ignition
     inline namespace IGNITION_SENSORS_VERSION_NAMESPACE {
 
     // \brief Reference frames enum
-    // NONE : To be used only when <localization>
-    // reference orintation tag is empty.
-    // ENU (East-North-Up): x - East, y - North, z - Up.
-    // NED (North-East-Down): x - North, y - East, z - Down.
-    // NWU (North-West-Up): x - North, y - West, z - Up.
-    // CUSTOM : The frame is described using custom_rpy tag.
     enum class IGNITION_SENSORS_VISIBLE WorldFrameEnumType
     {
+      // \brief NONE : To be used only when <localization>
+      // reference orintation tag is empty.
       NONE = 0,
+
+      // \brief ENU (East-North-Up): x - East, y - North, z - Up.
       ENU = 1,
+
+      // \brief NED (North-East-Down): x - North, y - East, z - Down.
       NED = 2,
+
+      // \brief NWU (North-West-Up): x - North, y - West, z - Up.
       NWU = 3,
+
+      // \brief CUSTOM : The frame is described using custom_rpy tag.
       CUSTOM = 4
     };
 

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -160,14 +160,6 @@ namespace ignition
       public: void SetWorldFrameOrientation(
         const math::Quaterniond &_rot, WorldFrameEnumType _relativeTo);
 
-      // \brief Read the localization sdf tag
-      // \param[in] _sdf Imu sdf data as sdf::Sensor
-      public: void ReadLocalizationTag(const sdf::Sensor &_sdf);
-
-      // \brief Read the localization sdf tag
-      // \param[in] _sdf Imu sdf data as sdf:;ElementPtr
-      public: void ReadLocalizationTag(sdf::ElementPtr _sdf);
-
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Data pointer for private data
       /// \internal

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -33,30 +33,30 @@ namespace ignition
 {
   namespace sensors
   {
-    // Inline bracket to help doxygen filtering.
+    /// Inline bracket to help doxygen filtering.
     inline namespace IGNITION_SENSORS_VERSION_NAMESPACE {
 
-    // \brief Reference frames enum
+    /// \brief Reference frames enum
     enum class IGNITION_SENSORS_VISIBLE WorldFrameEnumType
     {
-      // \brief NONE : To be used only when <localization>
-      // reference orintation tag is empty.
+      /// \brief NONE : To be used only when <localization>
+      /// reference orientation tag is empty.
       NONE = 0,
 
-      // \brief ENU (East-North-Up): x - East, y - North, z - Up.
+      /// \brief ENU (East-North-Up): x - East, y - North, z - Up.
       ENU = 1,
 
-      // \brief NED (North-East-Down): x - North, y - East, z - Down.
+      /// \brief NED (North-East-Down): x - North, y - East, z - Down.
       NED = 2,
 
-      // \brief NWU (North-West-Up): x - North, y - West, z - Up.
+      /// \brief NWU (North-West-Up): x - North, y - West, z - Up.
       NWU = 3,
 
-      // \brief CUSTOM : The frame is described using custom_rpy tag.
+      /// \brief CUSTOM : The frame is described using custom_rpy tag.
       CUSTOM = 4
     };
 
-    //
+    ///
     /// \brief forward declarations
     class ImuSensorPrivate;
 
@@ -158,9 +158,9 @@ namespace ignition
       public: math::Vector3d Gravity() const;
 
       /// \brief Specify the rotation offset of the coordinates of the World
-      //  frame relative to a geo-referenced frame
+      /// frame relative to a geo-referenced frame
       /// \param[in] _rot rotation offset
-      /// \param[in] _relativeTo world frame orintation, ENU by default
+      /// \param[in] _relativeTo world frame orientation, ENU by default
       public: void SetWorldFrameOrientation(
         const math::Quaterniond &_rot, WorldFrameEnumType _relativeTo);
 

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -42,7 +42,8 @@ namespace ignition
       NONE = 0,
       ENU = 1,
       NED = 2,
-      NWU = 3
+      NWU = 3,
+      CUSTOM = 4
     };
 
     //

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -83,10 +83,10 @@ class ignition::sensors::ImuSensorPrivate
          = WorldFrameEnumType::NONE;
 
   /// \brief Frame realtive to which custom_rpy is specified
-  public: std::string CustomRpyParentFrame;
+  public: std::string customRpyParentFrame;
 
   /// \brief Quaternion for to store custom_rpy
-  public: ignition::math::Quaterniond CustomRpyQuaternion;
+  public: ignition::math::Quaterniond customRpyQuaternion;
 
   /// \brief Previous update time step.
   public: std::chrono::steady_clock::duration prevStep
@@ -180,9 +180,9 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
     this->dataPtr->sensorOrientationRelativeTo = WorldFrameEnumType::NONE;
   }
 
-  this->dataPtr->CustomRpyParentFrame =
+  this->dataPtr->customRpyParentFrame =
       _sdf.ImuSensor()->CustomRpyParentFrame();
-  this->dataPtr->CustomRpyQuaternion = ignition::math::Quaterniond(
+  this->dataPtr->customRpyQuaternion = ignition::math::Quaterniond(
       _sdf.ImuSensor()->CustomRpy());
 
   this->dataPtr->initialized = true;
@@ -321,10 +321,10 @@ void ImuSensor::SetWorldFrameOrientation(
   // Set orientation reference frame if custom_rpy was supplied
   if (this->dataPtr->sensorOrientationRelativeTo == WorldFrameEnumType::CUSTOM)
   {
-    if (this->dataPtr->CustomRpyParentFrame == "")
+    if (this->dataPtr->customRpyParentFrame == "")
     {
       this->SetOrientationReference(this->dataPtr->worldRelativeOrientation *
-        this->dataPtr->CustomRpyQuaternion);
+        this->dataPtr->customRpyQuaternion);
     }
     else
     {

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -125,38 +125,6 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
     return false;
   }
 
-  // Set orientation reference frame
-  // TODO(adityapande-1995) : Add support for named frames like
-  // ENU using ign-gazebo
-  std::string localization = _sdf.ImuSensor()->Localization();
-
-  if (localization == "ENU")
-  {
-    this->dataPtr->localizationEnum = WorldFrameEnumType::ENU;
-  } else if (localization == "NED") {
-    this->dataPtr->localizationEnum = WorldFrameEnumType::NED;
-  } else if (localization == "NWU") {
-    this->dataPtr->localizationEnum = WorldFrameEnumType::NWU;
-  } else if (localization == "CUSTOM") {
-    this->dataPtr->localizationEnum = WorldFrameEnumType::CUSTOM;
-  } else {
-    this->dataPtr->localizationEnum = WorldFrameEnumType::NONE;
-  }
-
-  if (this->dataPtr->localizationEnum == WorldFrameEnumType::CUSTOM)
-  {
-    if (_sdf.ImuSensor()->CustomRpyParentFrame() == "")
-    {
-      this->SetOrientationReference(ignition::math::Quaterniond(
-        _sdf.ImuSensor()->CustomRpy()));
-    }
-    else
-    {
-      ignwarn << "custom_rpy parent frame must be set to empty "
-                "string. Setting it to any other frame is not "
-                "supported yet." << std::endl;
-    }
-  }
 
   if (this->Topic().empty())
     this->SetTopic("/imu");
@@ -314,6 +282,50 @@ void ImuSensor::SetWorldPose(const math::Pose3d _pose)
 math::Pose3d ImuSensor::WorldPose() const
 {
   return this->dataPtr->worldPose;
+}
+
+//////////////////////////////////////////////////
+void ImuSensor::ReadLocalizationTag(const sdf::Sensor &_sdf)
+{
+  std::string localization = _sdf.ImuSensor()->Localization();
+
+  if (localization == "ENU")
+  {
+    this->dataPtr->localizationEnum = WorldFrameEnumType::ENU;
+  } else if (localization == "NED") {
+    this->dataPtr->localizationEnum = WorldFrameEnumType::NED;
+  } else if (localization == "NWU") {
+    this->dataPtr->localizationEnum = WorldFrameEnumType::NWU;
+  } else if (localization == "CUSTOM") {
+    this->dataPtr->localizationEnum = WorldFrameEnumType::CUSTOM;
+  } else {
+    this->dataPtr->localizationEnum = WorldFrameEnumType::NONE;
+  }
+
+  // Set orientation reference frame if custom_rpy was supplied
+  if (this->dataPtr->localizationEnum == WorldFrameEnumType::CUSTOM)
+  {
+    if (_sdf.ImuSensor()->CustomRpyParentFrame() == "")
+    {
+      this->SetOrientationReference(ignition::math::Quaterniond(
+        _sdf.ImuSensor()->CustomRpy()));
+    }
+    else
+    {
+      ignwarn << "custom_rpy parent frame must be set to empty "
+                "string. Setting it to any other frame is not "
+                "supported yet." << std::endl;
+    }
+  }
+}
+
+
+//////////////////////////////////////////////////
+void ImuSensor::ReadLocalizationTag(sdf::ElementPtr _sdf)
+{
+  sdf::Sensor sdfSensor;
+  sdfSensor.Load(_sdf);
+  return this->ReadLocalizationTag(sdfSensor);
 }
 
 //////////////////////////////////////////////////

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -72,7 +72,7 @@ class ignition::sensors::ImuSensorPrivate
   public: bool timeInitialized = false;
   
   /// \brief Store world heading offset
-  public: Quaterniond headingOffset;
+  public: ignition::math::Quaterniond headingOffset;
 
   /// \brief Store world orientation
   public: std::string worldFrameType = "ENU";
@@ -142,48 +142,53 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
   }
 
   // Table to hold frame transformations
-  std::map<std::string, std::map<std::string, Quaterniond>> transformTable =
+  std::map<std::string, std::map<std::string, ignition::math::Quaterniond>> transformTable =
     {
-      "ENU":
+      {"ENU",
         {
-	  "ENU": Quaterniond(0, 0, 0),
-	  "NED": Quaterniond(0, 0, 0),  
-	  "NWU": Quaterniond(0, 0, 0),  
-	  "GRAV_UP": Quaterniond(0, 0, 0),  
-	  "GRAV_DOWN": Quaterniond(0, 0, 0)  
-	},
-      "NED":
+	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
+	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
+          {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
+          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
+	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
+	}
+      },
+      {"NED",
         {
-	  "ENU": Quaterniond(0, 0, 0),
-	  "NED": Quaterniond(0, 0, 0),  
-	  "NWU": Quaterniond(0, 0, 0),  
-	  "GRAV_UP": Quaterniond(0, 0, 0),  
-	  "GRAV_DOWN": Quaterniond(0, 0, 0)  
-	},
-      "NWU":
+	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
+	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
+          {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
+          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
+	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
+	}
+      },
+      {"NWU",
         {
-	  "ENU": Quaterniond(0, 0, 0),
-	  "NED": Quaterniond(0, 0, 0),  
-	  "NWU": Quaterniond(0, 0, 0),  
-	  "GRAV_UP": Quaterniond(0, 0, 0),  
-	  "GRAV_DOWN": Quaterniond(0, 0, 0)  
-	},
-      "GRAV_UP":
+	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
+	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
+          {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
+          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
+	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
+	}
+      },
+      {"GRAV_UP",
         {
-	  "ENU": Quaterniond(0, 0, 0),
-	  "NED": Quaterniond(0, 0, 0),  
-	  "NWU": Quaterniond(0, 0, 0),  
-	  "GRAV_UP": Quaterniond(0, 0, 0),  
-	  "GRAV_DOWN": Quaterniond(0, 0, 0)  
-	},
-      "GRAV_DOWN":
+	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
+	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
+          {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
+          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
+	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
+	}
+      },
+      {"GRAV_DOWN",
         {
-	  "ENU": Quaterniond(0, 0, 0),
-	  "NED": Quaterniond(0, 0, 0),  
-	  "NWU": Quaterniond(0, 0, 0),  
-	  "GRAV_UP": Quaterniond(0, 0, 0),  
-	  "GRAV_DOWN": Quaterniond(0, 0, 0)  
-	},
+	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
+	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
+          {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
+          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
+	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
+	}
+      }
     };
 
   if (transformTable.count(localization) != 0)
@@ -354,7 +359,7 @@ math::Pose3d ImuSensor::WorldPose() const
 }
 
 //////////////////////////////////////////////////
-void ImuSensor::SetWorldFrameOrientation(const Quaterniond &_rot, std::string _relativeTo) const
+void ImuSensor::SetWorldFrameOrientation(const math::Quaterniond &_rot, std::string _relativeTo)
 {
   this->dataPtr->headingOffset = _rot;
   this->dataPtr->worldFrameType = _relativeTo;

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -80,7 +80,7 @@ class ignition::sensors::ImuSensorPrivate
 
   /// \brief Frame relative-to which the sensor orientation is reported
   public: WorldFrameEnumType sensorOrientationRelativeTo
-	  = WorldFrameEnumType::NONE;
+         = WorldFrameEnumType::NONE;
 
   /// \brief Frame realtive to which custom_rpy is specified
   public: std::string CustomRpyParentFrame;
@@ -180,9 +180,10 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
     this->dataPtr->sensorOrientationRelativeTo = WorldFrameEnumType::NONE;
   }
 
-  this->dataPtr->CustomRpyParentFrame = _sdf.ImuSensor()->CustomRpyParentFrame();
+  this->dataPtr->CustomRpyParentFrame =
+      _sdf.ImuSensor()->CustomRpyParentFrame();
   this->dataPtr->CustomRpyQuaternion = ignition::math::Quaterniond(
-		                         _sdf.ImuSensor()->CustomRpy());
+      _sdf.ImuSensor()->CustomRpy());
 
   this->dataPtr->initialized = true;
   return true;
@@ -329,7 +330,7 @@ void ImuSensor::SetWorldFrameOrientation(
     }
     return;
   }
-  
+
   this->dataPtr->worldRelativeOrientation = _rot;
   this->dataPtr->worldFrameRelativeTo = _relativeTo;
 

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -147,46 +147,22 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
       {"ENU",
         {
 	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
-	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
-          {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
-          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
-	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
+	  {"NED", ignition::math::Quaterniond(1/std::sqrt(2), 1/std::sqrt(2), 0, 0)},  
+          {"NWU", ignition::math::Quaterniond(0, 0, IGN_PI/2)},  
 	}
       },
       {"NED",
         {
-	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
+	  {"ENU", ignition::math::Quaterniond(1/std::sqrt(2), 1/std::sqrt(2), 0, 0).Inverse()},
 	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
-          {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
-          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
-	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
+          {"NWU", ignition::math::Quaterniond(IGN_PI, 0, 0)},  
 	}
       },
       {"NWU",
         {
-	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
-	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
+	  {"ENU", ignition::math::Quaterniond(0, 0, -IGN_PI/2)},
+	  {"NED", ignition::math::Quaterniond(-IGN_PI, 0, 0)},  
           {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
-          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
-	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
-	}
-      },
-      {"GRAV_UP",
-        {
-	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
-	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
-          {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
-          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
-	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
-	}
-      },
-      {"GRAV_DOWN",
-        {
-	  {"ENU", ignition::math::Quaterniond(0, 0, 0)},
-	  {"NED", ignition::math::Quaterniond(0, 0, 0)},  
-          {"NWU", ignition::math::Quaterniond(0, 0, 0)},  
-          {"GRAV_UP", ignition::math::Quaterniond(0, 0, 0)},  
-	  {"GRAV_DOWN", ignition::math::Quaterniond(0, 0, 0)}  
 	}
       }
     };

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -79,7 +79,8 @@ class ignition::sensors::ImuSensorPrivate
   public: WorldFrameEnumType worldFrameRelativeTo = WorldFrameEnumType::ENU;
 
   /// \brief Frame relative-to which the sensor orientation is reported
-  public: WorldFrameEnumType sensorOrientationRelativeTo;
+  public: WorldFrameEnumType sensorOrientationRelativeTo
+	  = WorldFrameEnumType::NONE;
 
   /// \brief Frame realtive to which custom_rpy is specified
   public: std::string CustomRpyParentFrame;

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -315,12 +315,16 @@ math::Pose3d ImuSensor::WorldPose() const
 void ImuSensor::SetWorldFrameOrientation(
   const math::Quaterniond &_rot, WorldFrameEnumType _relativeTo)
 {
+  this->dataPtr->worldRelativeOrientation = _rot;
+  this->dataPtr->worldFrameRelativeTo = _relativeTo;
+
   // Set orientation reference frame if custom_rpy was supplied
   if (this->dataPtr->sensorOrientationRelativeTo == WorldFrameEnumType::CUSTOM)
   {
     if (this->dataPtr->CustomRpyParentFrame == "")
     {
-      this->SetOrientationReference(this->dataPtr->CustomRpyQuaternion);
+      this->SetOrientationReference(this->dataPtr->worldRelativeOrientation *
+        this->dataPtr->CustomRpyQuaternion);
     }
     else
     {
@@ -330,9 +334,6 @@ void ImuSensor::SetWorldFrameOrientation(
     }
     return;
   }
-
-  this->dataPtr->worldRelativeOrientation = _rot;
-  this->dataPtr->worldFrameRelativeTo = _relativeTo;
 
   // Table to hold frame transformations
   static const std::map<WorldFrameEnumType,

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -171,7 +171,6 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
     this->dataPtr->sensorOrientationRelativeTo = WorldFrameEnumType::ENU;
   } else if (localization == "NED") {
     this->dataPtr->sensorOrientationRelativeTo = WorldFrameEnumType::NED;
-    std::cout << "add: " << &(this->dataPtr->sensorOrientationRelativeTo) << std::endl;
   } else if (localization == "NWU") {
     this->dataPtr->sensorOrientationRelativeTo = WorldFrameEnumType::NWU;
   } else if (localization == "CUSTOM") {
@@ -314,8 +313,6 @@ math::Pose3d ImuSensor::WorldPose() const
 void ImuSensor::SetWorldFrameOrientation(
   const math::Quaterniond &_rot, WorldFrameEnumType _relativeTo)
 {
-  std::cout << "Debug 1" << std::endl;
-  std::cout << "add: " << &(this->dataPtr->sensorOrientationRelativeTo) << std::endl;
   // Set orientation reference frame if custom_rpy was supplied
   if (this->dataPtr->sensorOrientationRelativeTo == WorldFrameEnumType::CUSTOM)
   {

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -70,7 +70,7 @@ class ignition::sensors::ImuSensorPrivate
 
   /// \brief Flag for if time has been initialized
   public: bool timeInitialized = false;
-  
+
   /// \brief Store world heading offset
   public: ignition::math::Quaterniond headingOffset;
 
@@ -143,28 +143,34 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
 
   // Table to hold frame transformations
   std::map<WorldFrameEnumType,
-	  std::map<WorldFrameEnumType, ignition::math::Quaterniond>> transformTable =
+    std::map<WorldFrameEnumType, ignition::math::Quaterniond>>
+      transformTable =
     {
       {WorldFrameEnumType::ENU,
         {
-	  {WorldFrameEnumType::ENU, ignition::math::Quaterniond(0, 0, 0)},
-	  {WorldFrameEnumType::NED, ignition::math::Quaterniond(1/std::sqrt(2), 1/std::sqrt(2), 0, 0)},
-          {WorldFrameEnumType::NWU, ignition::math::Quaterniond(0, 0, IGN_PI/2)},
-	}
+          {WorldFrameEnumType::ENU, ignition::math::Quaterniond(0, 0, 0)},
+          {WorldFrameEnumType::NED, ignition::math::Quaterniond(
+            1/std::sqrt(2), 1/std::sqrt(2), 0, 0)},
+          {WorldFrameEnumType::NWU, ignition::math::Quaterniond(
+            0, 0, IGN_PI/2)},
+        }
       },
       {WorldFrameEnumType::NED,
         {
-	  {WorldFrameEnumType::ENU, ignition::math::Quaterniond(1/std::sqrt(2), 1/std::sqrt(2), 0, 0).Inverse()},
-	  {WorldFrameEnumType::NED, ignition::math::Quaterniond(0, 0, 0)},
-          {WorldFrameEnumType::NWU, ignition::math::Quaterniond(IGN_PI, 0, 0)},
-	}
+          {WorldFrameEnumType::ENU, ignition::math::Quaterniond(
+            1/std::sqrt(2), 1/std::sqrt(2), 0, 0).Inverse()},
+          {WorldFrameEnumType::NED, ignition::math::Quaterniond(0, 0, 0)},
+          {WorldFrameEnumType::NWU, ignition::math::Quaterniond(
+            IGN_PI, 0, 0)},
+        }
       },
       {WorldFrameEnumType::NWU,
         {
-	  {WorldFrameEnumType::ENU, ignition::math::Quaterniond(0, 0, -IGN_PI/2)},
-	  {WorldFrameEnumType::NED, ignition::math::Quaterniond(-IGN_PI, 0, 0)},
+          {WorldFrameEnumType::ENU, ignition::math::Quaterniond(
+            0, 0, -IGN_PI/2)},
+          {WorldFrameEnumType::NED, ignition::math::Quaterniond(-IGN_PI, 0, 0)},
           {WorldFrameEnumType::NWU, ignition::math::Quaterniond(0, 0, 0)},
-	}
+        }
       }
     };
 
@@ -184,10 +190,12 @@ bool ImuSensor::Load(const sdf::Sensor &_sdf)
   if (localizationEnum != WorldFrameEnumType::NONE)
   {
     // A valid localization tag is supplied in the sdf
-    auto tranformation = transformTable[this->dataPtr->worldFrameType][localizationEnum];
+    auto tranformation =
+      transformTable[this->dataPtr->worldFrameType][localizationEnum];
     this->SetOrientationReference(this->dataPtr->headingOffset * tranformation);
   } else {
-    ignwarn << "This localization tag is not supported: " << localization << std::endl;
+    ignwarn << "This localization tag is not supported: " << localization
+      << std::endl;
   }
 
   if (this->Topic().empty())
@@ -349,7 +357,8 @@ math::Pose3d ImuSensor::WorldPose() const
 }
 
 //////////////////////////////////////////////////
-void ImuSensor::SetWorldFrameOrientation(const math::Quaterniond &_rot, WorldFrameEnumType _relativeTo)
+void ImuSensor::SetWorldFrameOrientation(
+  const math::Quaterniond &_rot, WorldFrameEnumType _relativeTo)
 {
   this->dataPtr->headingOffset = _rot;
   this->dataPtr->worldFrameType = _relativeTo;

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -76,7 +76,7 @@ class ignition::sensors::ImuSensorPrivate
 
   /// \brief Store world orientation
   public: WorldFrameEnumType worldFrameType = WorldFrameEnumType::ENU;
-  
+
   /// \brief Store localization orientation
   public: WorldFrameEnumType localizationEnum = WorldFrameEnumType::NONE;
 
@@ -322,7 +322,7 @@ void ImuSensor::SetWorldFrameOrientation(
 {
   this->dataPtr->headingOffset = _rot;
   this->dataPtr->worldFrameType = _relativeTo;
-  
+
   // Table to hold frame transformations
   std::map<WorldFrameEnumType,
     std::map<WorldFrameEnumType, ignition::math::Quaterniond>>
@@ -361,7 +361,8 @@ void ImuSensor::SetWorldFrameOrientation(
   {
     // A valid named localization tag is supplied in the sdf
     auto tranformation =
-      transformTable[this->dataPtr->worldFrameType][this->dataPtr->localizationEnum];
+      transformTable[this->dataPtr->worldFrameType][
+      this->dataPtr->localizationEnum];
     this->SetOrientationReference(this->dataPtr->headingOffset * tranformation);
   }
 }

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -337,7 +337,7 @@ void ImuSensor::SetWorldFrameOrientation(
   this->dataPtr->worldFrameRelativeTo = _relativeTo;
 
   // Table to hold frame transformations
-  std::map<WorldFrameEnumType,
+  static const std::map<WorldFrameEnumType,
     std::map<WorldFrameEnumType, ignition::math::Quaterniond>>
       transformTable =
     {
@@ -374,8 +374,8 @@ void ImuSensor::SetWorldFrameOrientation(
   {
     // A valid named localization tag is supplied in the sdf
     auto tranformation =
-      transformTable[this->dataPtr->worldFrameRelativeTo][
-      this->dataPtr->sensorOrientationRelativeTo];
+      transformTable.at(this->dataPtr->worldFrameRelativeTo).at
+      (this->dataPtr->sensorOrientationRelativeTo);
     this->SetOrientationReference(this->dataPtr->worldRelativeOrientation *
       tranformation);
   }

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -440,6 +440,8 @@ TEST(ImuSensor_TEST, OrientationReference)
   // Make sure the above dynamic cast worked.
   ASSERT_NE(nullptr, sensor);
 
+  sensor->ReadLocalizationTag(imuSDF);
+
   sensor->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
 
@@ -498,6 +500,8 @@ TEST(ImuSensor_TEST, CustomRpyParentFrame)
 
   // Make sure the above dynamic cast worked.
   ASSERT_NE(nullptr, sensor);
+
+  sensor->ReadLocalizationTag(imuSDF);
 
   sensor->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
@@ -560,6 +564,7 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
   auto sensorENU = mgr.CreateSensor<ignition::sensors::ImuSensor>(
       generateSensor("ENU"));
   ASSERT_NE(nullptr, sensorENU);
+  sensorENU->ReadLocalizationTag(generateSensor("ENU"));
 
   // Case A.1 : Localization ref: ENU, World : ENU
   // Sensor aligns with ENU, we're measuring wrt ENU
@@ -601,6 +606,7 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
   auto sensorNWU = mgr.CreateSensor<ignition::sensors::ImuSensor>(
       generateSensor("NWU"));
   ASSERT_NE(nullptr, sensorNWU);
+  sensorNWU->ReadLocalizationTag(generateSensor("NWU"));
 
   // Case B.1 : Localization ref: NWU, World : NWU
   // Sensor aligns with NWU, we're measuring wrt NWU
@@ -642,6 +648,7 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
   auto sensorNED = mgr.CreateSensor<ignition::sensors::ImuSensor>(
       generateSensor("NED"));
   ASSERT_NE(nullptr, sensorNED);
+  sensorNED->ReadLocalizationTag(generateSensor("NED"));
 
   // Case C.1 : Localization ref: NED, World : NED
   // Sensor aligns with NED, we're measuring wrt NED

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -436,11 +436,11 @@ TEST(ImuSensor_TEST, OrientationReference)
   // Create an ImuSensor
   auto sensor = mgr.CreateSensor<ignition::sensors::ImuSensor>(
       imuSDF);
+  sensor->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::ENU);
 
   // Make sure the above dynamic cast worked.
   ASSERT_NE(nullptr, sensor);
-
-  sensor->ReadLocalizationTag(imuSDF);
 
   sensor->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
@@ -497,11 +497,12 @@ TEST(ImuSensor_TEST, CustomRpyParentFrame)
   // Create an ImuSensor
   auto sensor = mgr.CreateSensor<ignition::sensors::ImuSensor>(
       imuSDF);
+  
+  sensor->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::ENU);
 
   // Make sure the above dynamic cast worked.
   ASSERT_NE(nullptr, sensor);
-
-  sensor->ReadLocalizationTag(imuSDF);
 
   sensor->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
@@ -564,7 +565,6 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
   auto sensorENU = mgr.CreateSensor<ignition::sensors::ImuSensor>(
       generateSensor("ENU"));
   ASSERT_NE(nullptr, sensorENU);
-  sensorENU->ReadLocalizationTag(generateSensor("ENU"));
 
   // Case A.1 : Localization ref: ENU, World : ENU
   // Sensor aligns with ENU, we're measuring wrt ENU
@@ -606,7 +606,6 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
   auto sensorNWU = mgr.CreateSensor<ignition::sensors::ImuSensor>(
       generateSensor("NWU"));
   ASSERT_NE(nullptr, sensorNWU);
-  sensorNWU->ReadLocalizationTag(generateSensor("NWU"));
 
   // Case B.1 : Localization ref: NWU, World : NWU
   // Sensor aligns with NWU, we're measuring wrt NWU
@@ -648,7 +647,6 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
   auto sensorNED = mgr.CreateSensor<ignition::sensors::ImuSensor>(
       generateSensor("NED"));
   ASSERT_NE(nullptr, sensorNED);
-  sensorNED->ReadLocalizationTag(generateSensor("NED"));
 
   // Case C.1 : Localization ref: NED, World : NED
   // Sensor aligns with NED, we're measuring wrt NED

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -497,7 +497,7 @@ TEST(ImuSensor_TEST, CustomRpyParentFrame)
   // Create an ImuSensor
   auto sensor = mgr.CreateSensor<ignition::sensors::ImuSensor>(
       imuSDF);
-  
+
   sensor->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
     sensors::WorldFrameEnumType::ENU);
 

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -758,6 +758,63 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 }
 
 //////////////////////////////////////////////////
+TEST(ImuSensor_TEST, LocalizationTagEmpty)
+{
+  // Create a sensor manager
+  ignition::sensors::Manager mgr;
+
+  sdf::ElementPtr imuSDF;
+
+  std::ostringstream stream;
+  stream
+    << "<?xml version='1.0'?>"
+    << "<sdf version='1.6'>"
+    << " <model name='m1'>"
+    << "  <link name='link1'>"
+    << "    <sensor name='imu_sensor' type='imu'>"
+    << "      <topic>imu_test</topic>"
+    << "      <update_rate>1</update_rate>"
+    << "      <imu>"
+    << "      <orientation_reference_frame>"
+    << "      </orientation_reference_frame>"
+    << "      </imu>"
+    << "      <always_on>1</always_on>"
+    << "      <visualize>true</visualize>"
+    << "    </sensor>"
+    << "  </link>"
+    << " </model>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  if (!sdf::readString(stream.str(), sdfParsed))
+  {
+    imuSDF = sdf::ElementPtr();
+  }
+  else
+  {
+    imuSDF = sdfParsed->Root()->GetElement("model")->GetElement("link")
+      ->GetElement("sensor");
+  }
+
+  // Create an ImuSensor
+  auto sensor = mgr.CreateSensor<ignition::sensors::ImuSensor>(
+      imuSDF);
+  sensor->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::ENU);
+
+  // Make sure the above dynamic cast worked.
+  ASSERT_NE(nullptr, sensor);
+
+  sensor->Update(std::chrono::steady_clock::duration(
+    std::chrono::nanoseconds(10000000)));
+
+  math::Quaterniond orientValue(math::Vector3d(0, 0, 0));
+  EXPECT_EQ(orientValue, sensor->Orientation());
+
+}
+
+//////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -758,7 +758,7 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 }
 
 //////////////////////////////////////////////////
-TEST(ImuSensor_TEST, LocalizationTagEmpty)
+TEST(ImuSensor_TEST, LocalizationTagInvalid)
 {
   // Create a sensor manager
   ignition::sensors::Manager mgr;
@@ -776,6 +776,7 @@ TEST(ImuSensor_TEST, LocalizationTagEmpty)
     << "      <update_rate>1</update_rate>"
     << "      <imu>"
     << "      <orientation_reference_frame>"
+    << "      <localization>UNRECOGNIZED</localization>"
     << "      </orientation_reference_frame>"
     << "      </imu>"
     << "      <always_on>1</always_on>"
@@ -811,7 +812,6 @@ TEST(ImuSensor_TEST, LocalizationTagEmpty)
 
   math::Quaterniond orientValue(math::Vector3d(0, 0, 0));
   EXPECT_EQ(orientValue, sensor->Orientation());
-
 }
 
 //////////////////////////////////////////////////

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -561,16 +561,18 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
       generateSensor("ENU"));
   ASSERT_NE(nullptr, sensorENU);
 
-  // Case A.1 : Localization ref: ENU, World : ENU 
+  // Case A.1 : Localization ref: ENU, World : ENU
   // Sensor aligns with ENU, we're measuring wrt ENU
-  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0), sensors::WorldFrameEnumType::ENU);
+  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::ENU);
   sensorENU->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(0, 0, 0));
   EXPECT_EQ(orientValue, sensorENU->Orientation());
 
   // Case A.2 Localization ref: ENU, World : ENU + rotation offset
-  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, IGN_PI/4), sensors::WorldFrameEnumType::ENU);
+  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, IGN_PI/4),
+    sensors::WorldFrameEnumType::ENU);
   sensorENU->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(0, 0, -IGN_PI/4));
@@ -578,20 +580,22 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 
   // Case A.3 Localization ref: ENU, World : NWU
   // Sensor aligns with NWU, we're measuring wrt ENU
-  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0), sensors::WorldFrameEnumType::NWU);
+  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::NWU);
   sensorENU->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(0, 0, IGN_PI/2));
   EXPECT_EQ(orientValue, sensorENU->Orientation());
-  
-  // Case A.4 Localization ref: ENU, World : NED -- TODO
+
+  // Case A.4 Localization ref: ENU, World : NED
   // Sensor aligns with NED, we're measuring wrt ENU
-  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0), sensors::WorldFrameEnumType::NED);
+  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::NED);
   sensorENU->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(IGN_PI, 0, IGN_PI/2));
   EXPECT_EQ(orientValue, sensorENU->Orientation());
-  
+
   // B. Localization tag is set to NWU
   // ---------------------------------
   auto sensorNWU = mgr.CreateSensor<ignition::sensors::ImuSensor>(
@@ -600,14 +604,16 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 
   // Case B.1 : Localization ref: NWU, World : NWU
   // Sensor aligns with NWU, we're measuring wrt NWU
-  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0), sensors::WorldFrameEnumType::NWU);
+  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::NWU);
   sensorNWU->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(0, 0, 0));
   EXPECT_EQ(orientValue, sensorNWU->Orientation());
-  
+
   // Case B.2 : Localization ref: NWU, World : NWU + rotation offset
-  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, IGN_PI/4), sensors::WorldFrameEnumType::NWU);
+  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, IGN_PI/4),
+    sensors::WorldFrameEnumType::NWU);
   sensorNWU->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(0, 0, -IGN_PI/4));
@@ -615,20 +621,22 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 
   // Case B.3 : Localization ref: NWU, World : ENU
   // Sensor aligns with ENU, we're measuring wrt NWU
-  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0), sensors::WorldFrameEnumType::ENU);
+  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::ENU);
   sensorNWU->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(0, 0, -IGN_PI/2));
   EXPECT_EQ(orientValue, sensorNWU->Orientation());
-  
+
   // Case B.4 : Localization ref: NWU, World : NED
   // Sensor aligns with NED, we're measuring wrt NWU
-  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0), sensors::WorldFrameEnumType::NED);
+  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::NED);
   sensorNWU->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(IGN_PI, 0, 0));
   EXPECT_EQ(orientValue, sensorNWU->Orientation());
-  
+
   // C. Localization tag is set to NED
   // ---------------------------------
   auto sensorNED = mgr.CreateSensor<ignition::sensors::ImuSensor>(
@@ -637,14 +645,16 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 
   // Case C.1 : Localization ref: NED, World : NED
   // Sensor aligns with NED, we're measuring wrt NED
-  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0), sensors::WorldFrameEnumType::NED);
+  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::NED);
   sensorNED->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(0, 0, 0));
   EXPECT_EQ(orientValue, sensorNED->Orientation());
-  
+
   // Case C.2 : Localization ref: NED, World : NED + rotation offset
-  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, IGN_PI/4), sensors::WorldFrameEnumType::NED);
+  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, IGN_PI/4),
+    sensors::WorldFrameEnumType::NED);
   sensorNED->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(0, 0, -IGN_PI/4));
@@ -652,15 +662,17 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 
   // Case C.3 : Localization ref: NED, World : NWU
   // Sensor aligns with NWU, we're measuring wrt NED
-  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0), sensors::WorldFrameEnumType::NWU);
+  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::NWU);
   sensorNED->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(-IGN_PI, 0, 0));
   EXPECT_EQ(orientValue, sensorNED->Orientation());
 
-  // Case C.4 : Localization ref: NED, World : ENU -- TODO
+  // Case C.4 : Localization ref: NED, World : ENU
   // Sensor aligns with ENU, we're measuring wrt NED
-  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0), sensors::WorldFrameEnumType::ENU);
+  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
+    sensors::WorldFrameEnumType::ENU);
   sensorNED->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
   orientValue = math::Quaterniond(math::Vector3d(-IGN_PI, 0, IGN_PI/2));

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -516,7 +516,8 @@ TEST(ImuSensor_TEST, CustomRpyParentFrame)
   EXPECT_EQ(defultOrientValue, sensor->Orientation());
 }
 
-sdf::ElementPtr generateSensor(std::string namedFrame)
+sdf::ElementPtr sensorWithLocalization(
+  std::string _orientationLocalization)
 {
   std::ostringstream stream;
   stream
@@ -529,7 +530,7 @@ sdf::ElementPtr generateSensor(std::string namedFrame)
     << "      <update_rate>1</update_rate>"
     << "      <imu>"
     << "      <orientation_reference_frame>"
-    << "      <localization>"+namedFrame+"</localization>"
+    << "      <localization>"+_orientationLocalization+"</localization>"
     << "      </orientation_reference_frame>"
     << "      </imu>"
     << "      <always_on>1</always_on>"
@@ -563,7 +564,7 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
   // A. Localization tag is set to ENU
   // ---------------------------------
   auto sensorENU = mgr.CreateSensor<ignition::sensors::ImuSensor>(
-      generateSensor("ENU"));
+      sensorWithLocalization("ENU"));
   ASSERT_NE(nullptr, sensorENU);
 
   // Case A.1 : Localization ref: ENU, World : ENU
@@ -604,7 +605,7 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
   // B. Localization tag is set to NWU
   // ---------------------------------
   auto sensorNWU = mgr.CreateSensor<ignition::sensors::ImuSensor>(
-      generateSensor("NWU"));
+      sensorWithLocalization("NWU"));
   ASSERT_NE(nullptr, sensorNWU);
 
   // Case B.1 : Localization ref: NWU, World : NWU
@@ -645,7 +646,7 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
   // C. Localization tag is set to NED
   // ---------------------------------
   auto sensorNED = mgr.CreateSensor<ignition::sensors::ImuSensor>(
-      generateSensor("NED"));
+      sensorWithLocalization("NED"));
   ASSERT_NE(nullptr, sensorNED);
 
   // Case C.1 : Localization ref: NED, World : NED

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -569,38 +569,62 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 
   // Case A.1 : Localization ref: ENU, World : ENU
   // Sensor aligns with ENU, we're measuring wrt ENU
-  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
-    sensors::WorldFrameEnumType::ENU);
-  sensorENU->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(0, 0, 0));
-  EXPECT_EQ(orientValue, sensorENU->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, 0);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::ENU;
+    const math::Quaterniond expectedSensorOrientation(0, 0, 0);
+
+    sensorENU->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorENU->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorENU->Orientation());
+  }
 
   // Case A.2 Localization ref: ENU, World : ENU + rotation offset
-  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, IGN_PI/4),
-    sensors::WorldFrameEnumType::ENU);
-  sensorENU->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(0, 0, -IGN_PI/4));
-  EXPECT_EQ(orientValue, sensorENU->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, IGN_PI/4);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::ENU;
+    const math::Quaterniond expectedSensorOrientation(0, 0, -IGN_PI/4);
+
+    sensorENU->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorENU->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorENU->Orientation());
+  }
 
   // Case A.3 Localization ref: ENU, World : NWU
   // Sensor aligns with NWU, we're measuring wrt ENU
-  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
-    sensors::WorldFrameEnumType::NWU);
-  sensorENU->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(0, 0, IGN_PI/2));
-  EXPECT_EQ(orientValue, sensorENU->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, 0);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::NWU;
+    const math::Quaterniond expectedSensorOrientation(0, 0, IGN_PI/2);
+
+    sensorENU->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorENU->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorENU->Orientation());
+  }
 
   // Case A.4 Localization ref: ENU, World : NED
   // Sensor aligns with NED, we're measuring wrt ENU
-  sensorENU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
-    sensors::WorldFrameEnumType::NED);
-  sensorENU->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(IGN_PI, 0, IGN_PI/2));
-  EXPECT_EQ(orientValue, sensorENU->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, 0);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::NED;
+    const math::Quaterniond expectedSensorOrientation(IGN_PI, 0, IGN_PI/2);
+
+    sensorENU->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorENU->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorENU->Orientation());
+  }
 
   // B. Localization tag is set to NWU
   // ---------------------------------
@@ -610,38 +634,62 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 
   // Case B.1 : Localization ref: NWU, World : NWU
   // Sensor aligns with NWU, we're measuring wrt NWU
-  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
-    sensors::WorldFrameEnumType::NWU);
-  sensorNWU->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(0, 0, 0));
-  EXPECT_EQ(orientValue, sensorNWU->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, 0);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::NWU;
+    const math::Quaterniond expectedSensorOrientation(0, 0, 0);
+
+    sensorNWU->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorNWU->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorNWU->Orientation());
+  }
 
   // Case B.2 : Localization ref: NWU, World : NWU + rotation offset
-  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, IGN_PI/4),
-    sensors::WorldFrameEnumType::NWU);
-  sensorNWU->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(0, 0, -IGN_PI/4));
-  EXPECT_EQ(orientValue, sensorNWU->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, IGN_PI/4);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::NWU;
+    const math::Quaterniond expectedSensorOrientation(0, 0, -IGN_PI/4);
+
+    sensorNWU->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorNWU->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorNWU->Orientation());
+  }
 
   // Case B.3 : Localization ref: NWU, World : ENU
   // Sensor aligns with ENU, we're measuring wrt NWU
-  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
-    sensors::WorldFrameEnumType::ENU);
-  sensorNWU->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(0, 0, -IGN_PI/2));
-  EXPECT_EQ(orientValue, sensorNWU->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, 0);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::ENU;
+    const math::Quaterniond expectedSensorOrientation(0, 0, -IGN_PI/2);
+
+    sensorNWU->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorNWU->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorNWU->Orientation());
+  }
 
   // Case B.4 : Localization ref: NWU, World : NED
   // Sensor aligns with NED, we're measuring wrt NWU
-  sensorNWU->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
-    sensors::WorldFrameEnumType::NED);
-  sensorNWU->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(IGN_PI, 0, 0));
-  EXPECT_EQ(orientValue, sensorNWU->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, 0);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::NED;
+    const math::Quaterniond expectedSensorOrientation(IGN_PI, 0, 0);
+
+    sensorNWU->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorNWU->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorNWU->Orientation());
+  }
 
   // C. Localization tag is set to NED
   // ---------------------------------
@@ -651,38 +699,62 @@ TEST(ImuSensor_TEST, NamedFrameOrientationReference)
 
   // Case C.1 : Localization ref: NED, World : NED
   // Sensor aligns with NED, we're measuring wrt NED
-  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
-    sensors::WorldFrameEnumType::NED);
-  sensorNED->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(0, 0, 0));
-  EXPECT_EQ(orientValue, sensorNED->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, 0);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::NED;
+    const math::Quaterniond expectedSensorOrientation(0, 0, 0);
+
+    sensorNED->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorNED->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorNED->Orientation());
+  }
 
   // Case C.2 : Localization ref: NED, World : NED + rotation offset
-  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, IGN_PI/4),
-    sensors::WorldFrameEnumType::NED);
-  sensorNED->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(0, 0, -IGN_PI/4));
-  EXPECT_EQ(orientValue, sensorNED->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, IGN_PI/4);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::NED;
+    const math::Quaterniond expectedSensorOrientation(0, 0, -IGN_PI/4);
+
+    sensorNED->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorNED->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorNED->Orientation());
+  }
 
   // Case C.3 : Localization ref: NED, World : NWU
   // Sensor aligns with NWU, we're measuring wrt NED
-  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
-    sensors::WorldFrameEnumType::NWU);
-  sensorNED->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(-IGN_PI, 0, 0));
-  EXPECT_EQ(orientValue, sensorNED->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, 0);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::NWU;
+    const math::Quaterniond expectedSensorOrientation(-IGN_PI, 0, 0);
+
+    sensorNED->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorNED->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorNED->Orientation());
+  }
 
   // Case C.4 : Localization ref: NED, World : ENU
   // Sensor aligns with ENU, we're measuring wrt NED
-  sensorNED->SetWorldFrameOrientation(math::Quaterniond(0, 0, 0),
-    sensors::WorldFrameEnumType::ENU);
-  sensorNED->Update(std::chrono::steady_clock::duration(
-    std::chrono::nanoseconds(10000000)));
-  orientValue = math::Quaterniond(math::Vector3d(-IGN_PI, 0, IGN_PI/2));
-  EXPECT_EQ(orientValue, sensorNED->Orientation());
+  {
+    const math::Quaterniond worldFrameOrientation(0, 0, 0);
+    const sensors::WorldFrameEnumType worldRelativeTo =
+      sensors::WorldFrameEnumType::ENU;
+    const math::Quaterniond expectedSensorOrientation(-IGN_PI, 0, IGN_PI/2);
+
+    sensorNED->SetWorldFrameOrientation(worldFrameOrientation,
+      worldRelativeTo);
+    sensorNED->Update(std::chrono::steady_clock::duration(
+      std::chrono::nanoseconds(10000000)));
+    EXPECT_EQ(expectedSensorOrientation, sensorNED->Orientation());
+  }
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

## Summary
As per the discussion here : https://github.com/ignitionrobotics/ign-sensors/pull/178#discussion_r780604658, this PR aims to expose ``SetWorldFrameOrientation`` API which accepts heading offset and world frame orientation (``ENU`` by default). If the ``<localization>`` tag for IMU sensor is set to any named frame (https://github.com/ignitionrobotics/sdformat/blob/6404afdf959982f759526dea8700037b50fa7758/sdf/1.9/imu.sdf#L7-L30), the sensor should output its orientation with respect to the frame specified in the ``<localization>`` tag.

There would be another follow up PR in IMU sensor system to use this API

## Test it
Added some test cases to ``ImuSensor_TEST.cc``

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸