### PR TITLE
Let derived sensors call Sensor::Update

### DIFF
--- a/include/ignition/sensors/AirPressureSensor.hh
+++ b/include/ignition/sensors/AirPressureSensor.hh
@@ -64,6 +64,8 @@ namespace ignition
       /// \return True on success
       public: virtual bool Init() override;
 
+      using Sensor::Update;
+
       /// \brief Update the sensor and generate data
       /// \param[in] _now The current time
       /// \return true if the update was successfull

--- a/include/ignition/sensors/AltimeterSensor.hh
+++ b/include/ignition/sensors/AltimeterSensor.hh
@@ -64,6 +64,8 @@ namespace ignition
       /// \return True on success
       public: virtual bool Init() override;
 
+      using Sensor::Update;
+
       /// \brief Update the sensor and generate data
       /// \param[in] _now The current time
       /// \return true if the update was successfull

--- a/include/ignition/sensors/CameraSensor.hh
+++ b/include/ignition/sensors/CameraSensor.hh
@@ -90,6 +90,8 @@ namespace ignition
       /// \return True on success
       public: virtual bool Init() override;
 
+      using Sensor::Update;
+
       /// \brief Force the sensor to generate data
       /// \param[in] _now The current time
       /// \return true if the update was successfull

--- a/include/ignition/sensors/ForceTorqueSensor.hh
+++ b/include/ignition/sensors/ForceTorqueSensor.hh
@@ -67,6 +67,8 @@ namespace ignition
       /// \return True on success
       public: virtual bool Init() override;
 
+      using Sensor::Update;
+
       /// \brief Update the sensor and generate data
       /// \param[in] _now The current time
       /// \return true if the update was successfull

--- a/include/ignition/sensors/ImuSensor.hh
+++ b/include/ignition/sensors/ImuSensor.hh
@@ -65,6 +65,8 @@ namespace ignition
       /// \return True on success
       public: virtual bool Init() override;
 
+      using Sensor::Update;
+
       /// \brief Update the sensor and generate data
       /// \param[in] _now The current time
       /// \return true if the update was successfull

--- a/include/ignition/sensors/LogicalCameraSensor.hh
+++ b/include/ignition/sensors/LogicalCameraSensor.hh
@@ -75,6 +75,8 @@ namespace ignition
       /// \return True on success
       public: virtual bool Init() override;
 
+      using Sensor::Update;
+
       /// \brief Force the sensor to generate data
       /// \param[in] _now The current time
       /// \return true if the update was successfull

--- a/include/ignition/sensors/MagnetometerSensor.hh
+++ b/include/ignition/sensors/MagnetometerSensor.hh
@@ -65,6 +65,8 @@ namespace ignition
       /// \return True on success
       public: virtual bool Init() override;
 
+      using Sensor::Update;
+
       /// \brief Update the sensor and generate data
       /// \param[in] _now The current time
       /// \return true if the update was successfull

--- a/test/integration/air_pressure.cc
+++ b/test/integration/air_pressure.cc
@@ -209,7 +209,7 @@ TEST_F(AirPressureSensorTest, SensorReadings)
   WaitForMessageTestHelper<ignition::msgs::FluidPressure>
     msgHelperNoise(topicNoise);
   sensorNoise->Update(std::chrono::steady_clock::duration(
-      std::chrono::seconds(1)));
+      std::chrono::seconds(1)), false);
   EXPECT_TRUE(msgHelperNoise.WaitForMessage()) << msgHelperNoise;
   auto msgNoise = msgHelperNoise.Message();
   EXPECT_EQ(1, msg.header().stamp().sec());

--- a/test/integration/altimeter.cc
+++ b/test/integration/altimeter.cc
@@ -235,7 +235,7 @@ TEST_F(AltimeterSensorTest, SensorReadings)
   WaitForMessageTestHelper<ignition::msgs::Altimeter>
     msgHelperNoise(topicNoise);
   sensorNoise->Update(std::chrono::steady_clock::duration(
-    std::chrono::seconds(1)));
+    std::chrono::seconds(1)), false);
   EXPECT_TRUE(msgHelperNoise.WaitForMessage()) << msgHelperNoise;
   auto msgNoise = msgHelperNoise.Message();
   EXPECT_EQ(1, msg.header().stamp().sec());

--- a/test/integration/force_torque.cc
+++ b/test/integration/force_torque.cc
@@ -238,7 +238,7 @@ TEST_P(ForceTorqueSensorTest, SensorReadings)
   sensor->SetRotationParentInSensor(rotParentInSensor);
   EXPECT_EQ(rotParentInSensor, sensor->RotationParentInSensor());
 
-  sensor->Update(dt);
+  sensor->Update(dt, false);
   EXPECT_TRUE(msgHelper.WaitForMessage()) << msgHelper;
   auto msg = msgHelper.Message();
   EXPECT_EQ(1, msg.header().stamp().sec());

--- a/test/integration/imu.cc
+++ b/test/integration/imu.cc
@@ -196,7 +196,7 @@ TEST_F(ImuSensorTest, SensorReadings)
 
   // update sensor and verify new readings
   EXPECT_TRUE(sensor->Update(std::chrono::steady_clock::duration(
-    std::chrono::seconds(2))));
+    std::chrono::seconds(2))), false);
   EXPECT_EQ(orientRef, sensor->OrientationReference());
   EXPECT_EQ(gravity, sensor->Gravity());
   EXPECT_EQ(angularVel, sensor->AngularVelocity());

--- a/test/integration/imu.cc
+++ b/test/integration/imu.cc
@@ -196,7 +196,7 @@ TEST_F(ImuSensorTest, SensorReadings)
 
   // update sensor and verify new readings
   EXPECT_TRUE(sensor->Update(std::chrono::steady_clock::duration(
-    std::chrono::seconds(2))), false);
+    std::chrono::seconds(2)), false));
   EXPECT_EQ(orientRef, sensor->OrientationReference());
   EXPECT_EQ(gravity, sensor->Gravity());
   EXPECT_EQ(angularVel, sensor->AngularVelocity());

--- a/test/integration/logical_camera.cc
+++ b/test/integration/logical_camera.cc
@@ -192,7 +192,7 @@ TEST_F(LogicalCameraSensorTest, DetectBox)
   sensor->SetModelPoses(std::move(modelPoses2));
 
   // update
-  sensor->Update(std::chrono::steady_clock::duration::zero());
+  sensor->Update(std::chrono::steady_clock::duration::zero(), false);
 
   // verify box is not in the image
   img = sensor->Image();

--- a/test/integration/magnetometer.cc
+++ b/test/integration/magnetometer.cc
@@ -241,7 +241,7 @@ TEST_F(MagnetometerSensorTest, SensorReadings)
   EXPECT_EQ(worldField, sensor->MagneticField());
 
   EXPECT_TRUE(sensorNoise->Update(std::chrono::steady_clock::duration(
-    std::chrono::seconds(1))));
+    std::chrono::seconds(1))), false);
   EXPECT_EQ(poseNoise, sensorNoise->WorldPose());
   EXPECT_EQ(worldFieldNoise, sensorNoise->WorldMagneticField());
   // There should be noise in the MagneticField

--- a/test/integration/magnetometer.cc
+++ b/test/integration/magnetometer.cc
@@ -241,7 +241,7 @@ TEST_F(MagnetometerSensorTest, SensorReadings)
   EXPECT_EQ(worldField, sensor->MagneticField());
 
   EXPECT_TRUE(sensorNoise->Update(std::chrono::steady_clock::duration(
-    std::chrono::seconds(1))), false);
+    std::chrono::seconds(1)), false));
   EXPECT_EQ(poseNoise, sensorNoise->WorldPose());
   EXPECT_EQ(worldFieldNoise, sensorNoise->WorldMagneticField());
   // There should be noise in the MagneticField


### PR DESCRIPTION
# 🦟 Bug fix

* Related to https://github.com/ignitionrobotics/ign-gazebo/pull/1282

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Ignition Gazebo calls update directly on non-rendering sensors, but it's easy to call the "wrong" function if one is not careful. There are 2 `Update` functions on the base class:

1. `public: bool Update(const std::chrono::steady_clock::duration &_now, const bool _force);`
1. `public: virtual bool Update(const std::chrono::steady_clock::duration &_now) = 0;`

Most (all?) of the time, one would want to call `1.`, which calls `2.` under the hood and performs extra steps. But since `2.` is also public, and easier to call, we often call `2.` directly by mistake.

This PR solves one of the issues by making it easier to call the base class's function. The test changes in this PR wouldn't be possible without the `using` lines, for example. Also see the `ign-gazebo` PR:

* https://github.com/ignitionrobotics/ign-gazebo/pull/1283

We should consider also making the virtual function private, which will require a tick-tock cycle.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
