### PR TITLE
Fix compiler warnings (CMP0072 and copy elision)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ set(IGN_TRANSPORT_VER ${ignition-transport8_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-rendering
+
+# See CMP0072 for more details (cmake --help-policy CMP0072)
+if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
+  set(OpenGL_GL_PREFERENCE "GLVND")
+endif()
+
 ign_find_package(ignition-rendering3 REQUIRED OPTIONAL_COMPONENTS ogre ogre2)
 set(IGN_RENDERING_VER ${ignition-rendering3_VERSION_MAJOR})
 

--- a/src/SensorFactory.cc
+++ b/src/SensorFactory.cc
@@ -137,7 +137,7 @@ std::unique_ptr<Sensor> SensorFactory::CreateSensor(const sdf::Sensor &_sdf)
   }
 
   result.reset(sensor);
-  return std::move(result);
+  return result;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

We've been having CMP0072 policy warnings on Jenkins CI since we upgraded to Focal, see

* https://github.com/ignition-tooling/release-tools/pull/565
* https://github.com/ignitionrobotics/ign-rendering/issues/360

This PR takes the same approach as https://github.com/ignitionrobotics/ign-rendering/pull/528 to silence the CMP0072 warning.

I also tackled this other warning that I see locally with gcc 9.3, but is not coming up on CI yet:

```
/home/chapulina/dev_focal/ws_citadel/src/ign-sensors/src/SensorFactory.cc:140:19: warning: moving a local object in a return statement preve
nts copy elision [-Wpessimizing-move]            
  140 |   return std::move(result);                                                                                                         
      |          ~~~~~~~~~^~~~~~~~  
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
