### PR TITLE
Distortion Camera Sensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
   set(OpenGL_GL_PREFERENCE "GLVND")
 endif()
 
-ign_find_package(ignition-rendering6 REQUIRED OPTIONAL_COMPONENTS ogre ogre2)
+ign_find_package(ignition-rendering6 REQUIRED VERSION 6.2 OPTIONAL_COMPONENTS ogre ogre2)
 set(IGN_RENDERING_VER ${ignition-rendering6_VERSION_MAJOR})
 
 if (TARGET ignition-rendering${IGN_RENDERING_VER}::ogre)

--- a/include/ignition/sensors/BrownDistortionModel.hh
+++ b/include/ignition/sensors/BrownDistortionModel.hh
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef IGNITION_SENSORS_BROWNDISTORTIONMODEL_HH_
+#define IGNITION_SENSORS_BROWNDISTORTIONMODEL_HH_
+
+#include <sdf/sdf.hh>
+
+#include "ignition/sensors/config.hh"
+#include "ignition/sensors/Export.hh"
+#include "ignition/sensors/Distortion.hh"
+
+namespace ignition
+{
+  namespace sensors
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_SENSORS_VERSION_NAMESPACE {
+    //
+    // Forward declarations
+    class BrownDistortionModelPrivate;
+
+    /** \class BrownDistortionModel BrownDistortionModel.hh \
+    ignition/sensors/BrownDistortionModel.hh
+    **/
+    /// \brief Brown Distortion Model class
+    class IGNITION_SENSORS_VISIBLE BrownDistortionModel : public Distortion
+    {
+      /// \brief Constructor.
+      public: BrownDistortionModel();
+
+      /// \brief Destructor.
+      public: virtual ~BrownDistortionModel();
+
+      // Documentation inherited.
+      public: virtual void Load(const sdf::Camera &_sdf) override;
+
+      /// \brief Get the radial distortion coefficient k1.
+      /// \return Distortion coefficient k1.
+      public: double K1() const;
+
+      /// \brief Get the radial distortion coefficient k2.
+      /// \return Distortion coefficient k2.
+      public: double K2() const;
+
+      /// \brief Get the radial distortion coefficient k3.
+      /// \return Distortion coefficient k3.
+      public: double K3() const;
+
+      /// \brief Get the tangential distortion coefficient p1.
+      /// \return Distortion coefficient p1.
+      public: double P1() const;
+
+      /// \brief Get the tangential distortion coefficient p2.
+      /// \return Distortion coefficient p2.
+      public: double P2() const;
+
+      /// \brief Get the distortion center.
+      /// \return Distortion center.
+      public: math::Vector2d Center() const;
+
+      /// Documentation inherited
+      public: virtual void Print(std::ostream &_out) const override;
+
+      /// \brief Private data pointer.
+      private: BrownDistortionModelPrivate *dataPtr = nullptr;
+    };
+  }
+  }
+}
+
+#endif

--- a/include/ignition/sensors/BrownDistortionModel.hh
+++ b/include/ignition/sensors/BrownDistortionModel.hh
@@ -20,9 +20,10 @@
 
 #include <sdf/sdf.hh>
 
-#include "ignition/sensors/config.hh"
-#include "ignition/sensors/Export.hh"
 #include "ignition/sensors/Distortion.hh"
+#include "ignition/sensors/Export.hh"
+#include "ignition/sensors/config.hh"
+#include "ignition/utils/ImplPtr.hh"
 
 namespace ignition
 {
@@ -77,7 +78,7 @@ namespace ignition
       public: virtual void Print(std::ostream &_out) const override;
 
       /// \brief Private data pointer.
-      private: BrownDistortionModelPrivate *dataPtr = nullptr;
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
   }
   }

--- a/include/ignition/sensors/Distortion.hh
+++ b/include/ignition/sensors/Distortion.hh
@@ -22,9 +22,10 @@
 #include <string>
 #include <vector>
 
-#include <ignition/sensors/config.hh>
-#include <ignition/sensors/SensorTypes.hh>
 #include <ignition/sensors/Export.hh>
+#include <ignition/sensors/SensorTypes.hh>
+#include <ignition/sensors/config.hh>
+#include <ignition/utils/ImplPtr.hh>
 
 #include <sdf/sdf.hh>
 
@@ -99,7 +100,7 @@ namespace ignition
       public: virtual void Print(std::ostream &_out) const;
 
       /// \brief Private data pointer
-      private: DistortionPrivate *dataPtr = nullptr;
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
     }
   }

--- a/include/ignition/sensors/Distortion.hh
+++ b/include/ignition/sensors/Distortion.hh
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef IGNITION_SENSORS_DISTORTION_HH_
+#define IGNITION_SENSORS_DISTORTION_HH_
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <ignition/sensors/config.hh>
+#include <ignition/sensors/SensorTypes.hh>
+#include <ignition/sensors/Export.hh>
+
+#include <sdf/sdf.hh>
+
+namespace ignition
+{
+  namespace sensors
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_SENSORS_VERSION_NAMESPACE {
+    // Forward declarations
+    class DistortionPrivate;
+
+    /// \class DistortionFactory Distortion.hh ignition/sensors/Distortion.hh
+    /// \brief Use this distortion manager for creating and loading distortion
+    /// models.
+    class IGNITION_SENSORS_VISIBLE DistortionFactory
+    {
+      /// \brief Load a distortion model based on the input sdf parameters and
+      /// sensor type.
+      /// \param[in] _sdf Distortion sdf parameters.
+      /// \param[in] _sensorType Type of sensor. This is currently used to
+      /// distinguish between image and non image sensors in order to create
+      /// the appropriate distortion model.
+      /// \return Pointer to the distortion model created.
+      public: static DistortionPtr NewDistortionModel(sdf::ElementPtr _sdf,
+          const std::string &_sensorType = "");
+
+      /// \brief Load a distortion model based on the input sdf parameters and
+      /// sensor type.
+      /// \param[in] _sdf Distortion sdf parameters.
+      /// \param[in] _sensorType Type of sensor. This is currently used to
+      /// distinguish between image and non image sensors in order to create
+      /// the appropriate distortion model.
+      /// \return Pointer to the distortion model created.
+      public: static DistortionPtr NewDistortionModel(
+                  const sdf::Camera &_sdf,
+                  const std::string &_sensorType = "");
+    };
+
+    /// \brief Which distortion types we support
+    enum class IGNITION_SENSORS_VISIBLE DistortionType : int
+    {
+      NONE = 0,
+      CUSTOM = 1,
+      BROWN = 2
+    };
+
+    /// \class Distortion Distortion.hh ignition/sensors/Distortion.hh
+    /// \brief Distortion models for sensor output signals.
+    class IGNITION_SENSORS_VISIBLE Distortion
+    {
+      /// \brief Constructor. This should not be called directly unless creating
+      /// an empty distortion model. Use DistortionFactory::NewDistortionModel
+      /// to instantiate a new distortion model.
+      /// \param[in] _type Type of distortion model.
+      /// \sa DistortionFactory::NewDistortionModel
+      public: explicit Distortion(DistortionType _type);
+
+      /// \brief Destructor.
+      public: virtual ~Distortion();
+
+      /// \brief Load distortion parameters from sdf.
+      /// \param[in] _sdf SDF Distortion DOM object.
+      public: virtual void Load(const sdf::Camera &_sdf);
+
+      /// \brief Accessor for DistortionType.
+      /// \return Type of distortion currently in use.
+      public: DistortionType Type() const;
+
+      /// \brief Output information about the distortion model.
+      /// \param[in] _out Output stream
+      public: virtual void Print(std::ostream &_out) const;
+
+      /// \brief Private data pointer
+      private: DistortionPrivate *dataPtr = nullptr;
+    };
+    }
+  }
+}
+#endif

--- a/include/ignition/sensors/ImageBrownDistortionModel.hh
+++ b/include/ignition/sensors/ImageBrownDistortionModel.hh
@@ -20,7 +20,7 @@
 
 #include <sdf/sdf.hh>
 
-// TODO Remove these pragmas once ign-rendering is disabling the
+// TODO(WilliamLewww): Remove these pragmas once ign-rendering is disabling the
 // warnings
 #ifdef _WIN32
 #pragma warning(push)

--- a/include/ignition/sensors/ImageBrownDistortionModel.hh
+++ b/include/ignition/sensors/ImageBrownDistortionModel.hh
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef IGNITION_SENSORS_IMAGEBROWNDISTORTIONMODEL_HH_
+#define IGNITION_SENSORS_IMAGEBROWNDISTORTIONMODEL_HH_
+
+#include <sdf/sdf.hh>
+
+// TODO Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/Camera.hh>
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
+
+#include "ignition/sensors/config.hh"
+#include "ignition/sensors/BrownDistortionModel.hh"
+#include "ignition/sensors/rendering/Export.hh"
+
+namespace ignition
+{
+  namespace sensors
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_SENSORS_VERSION_NAMESPACE {
+    // Forward declarations
+    class ImageBrownDistortionModelPrivate;
+
+    /** \class ImageBrownDistortionModel ImageBrownDistortionModel.hh \
+    ignition/sensors/ImageBrownDistortionModel.hh
+    **/
+    /// \brief Distortion Model class for image sensors
+    class IGNITION_SENSORS_RENDERING_VISIBLE ImageBrownDistortionModel :
+      public BrownDistortionModel
+    {
+      /// \brief Constructor.
+      public: ImageBrownDistortionModel();
+
+      /// \brief Destructor.
+      public: virtual ~ImageBrownDistortionModel();
+
+      // Documentation inherited.
+      public: virtual void Load(const sdf::Camera &_sdf) override;
+
+      // Documentation inherited.
+      public: virtual void SetCamera(rendering::CameraPtr _camera);
+
+      /// Documentation inherited
+      public: virtual void Print(std::ostream &_out) const override;
+
+      /// \brief Private data pointer.
+      private: ImageBrownDistortionModelPrivate *dataPtr = nullptr;
+    };
+  }
+  }
+}
+
+#endif

--- a/include/ignition/sensors/ImageDistortion.hh
+++ b/include/ignition/sensors/ImageDistortion.hh
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef IGNITION_SENSORS_IMAGEDISTORTION_HH_
+#define IGNITION_SENSORS_IMAGEDISTORTION_HH_
+
+#include <string>
+
+#include <sdf/sdf.hh>
+
+#include "ignition/sensors/config.hh"
+#include "ignition/sensors/SensorTypes.hh"
+#include "ignition/sensors/rendering/Export.hh"
+
+namespace ignition
+{
+  namespace sensors
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_SENSORS_VERSION_NAMESPACE {
+    // Forward declarations
+    class DistortionPrivate;
+
+    /// \class ImageDistortionFactory ImageDistortion.hh
+    /// ignition/sensors/ImageDistortion.hh
+    /// \brief Use this distortion manager for creating and loading distortion
+    /// models.
+    class IGNITION_SENSORS_RENDERING_VISIBLE ImageDistortionFactory
+    {
+      /// \brief Load a distortion model based on the input sdf parameters and
+      /// sensor type.
+      /// \param[in] _sdf Distortion sdf parameters.
+      /// \param[in] _sensorType Type of sensor. This is currently used to
+      /// distinguish between image and non image sensors in order to create
+      /// the appropriate distortion model.
+      /// \return Pointer to the distortion model created.
+      public: static DistortionPtr NewDistortionModel(sdf::ElementPtr _sdf,
+          const std::string &_sensorType = "");
+
+      /// \brief Load a distortion model based on the input sdf parameters and
+      /// sensor type.
+      /// \param[in] _sdf Distortion sdf parameters.
+      /// \param[in] _sensorType Type of sensor. This is currently used to
+      /// distinguish between image and non image sensors in order to create
+      /// the appropriate distortion model.
+      /// \return Pointer to the distortion model created.
+      public: static DistortionPtr NewDistortionModel(const sdf::Camera &_sdf,
+                  const std::string &_sensorType = "");
+    };
+    }
+  }
+}
+#endif

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -208,5 +208,4 @@ namespace ignition
     }
   }
 }
-
 #endif

--- a/include/ignition/sensors/SensorTypes.hh
+++ b/include/ignition/sensors/SensorTypes.hh
@@ -229,7 +229,7 @@ namespace ignition
       /// \brief Noise streams for the Camera sensor
       /// \sa CameraSensor
       CAMERA_DISTORTION = 1,
-      
+
       /// \internal
       /// \brief Indicator used to create an iterator over the enum. Do not
       /// use this.

--- a/include/ignition/sensors/SensorTypes.hh
+++ b/include/ignition/sensors/SensorTypes.hh
@@ -42,6 +42,9 @@ namespace ignition
     class GaussianNoiseModel;
     class ImageGaussianNoiseModel;
     class Noise;
+    class Distortion;
+    class BrownDistortionModel;
+    class ImageBrownDistortionModel;
     class Sensor;
 
     /// \def SensorPtr
@@ -67,6 +70,19 @@ namespace ignition
     /// \brief Shared pointer to Noise
     typedef std::shared_ptr<ImageGaussianNoiseModel>
         ImageGaussianNoiseModelPtr;
+
+    /// \def DistortionPtr
+    /// \brief Shared pointer to Distortion
+    typedef std::shared_ptr<Distortion> DistortionPtr;
+
+    /// \def DistortionPtr
+    /// \brief Shared pointer to Distortion
+    typedef std::shared_ptr<BrownDistortionModel> BrownDistortionModelPtr;
+
+    /// \def DistortionPtr
+    /// \brief Shared pointer to Distortion
+    typedef std::shared_ptr<ImageBrownDistortionModel>
+        ImageBrownDistortionModelPtr;
 
     /// \def Sensor_V
     /// \brief Vector of Sensor shared pointers

--- a/include/ignition/sensors/SensorTypes.hh
+++ b/include/ignition/sensors/SensorTypes.hh
@@ -212,6 +212,31 @@ namespace ignition
     };
     /// \}
 
+
+    /// \def SensorDistortionType
+    /// \brief Eumeration of all sensor noise types
+    enum SensorDistortionType
+    {
+      /// \internal
+      /// \brief Indicator used to create an iterator over the enum. Do not
+      /// use this.
+      SENSOR_DISTORTION_TYPE_BEGIN = 0,
+
+      /// \brief Noise streams for the Camera sensor
+      /// \sa CameraSensor
+      NO_DISTORTION = SENSOR_DISTORTION_TYPE_BEGIN,
+
+      /// \brief Noise streams for the Camera sensor
+      /// \sa CameraSensor
+      CAMERA_DISTORTION = 1,
+      
+      /// \internal
+      /// \brief Indicator used to create an iterator over the enum. Do not
+      /// use this.
+      SENSOR_DISTORTION_TYPE_END
+    };
+    /// \}
+
     /// \brief SensorCategory is used to categorize sensors. This is used to
     /// put sensors into different threads.
     enum SensorCategory

--- a/src/BrownDistortionModel.cc
+++ b/src/BrownDistortionModel.cc
@@ -31,33 +31,29 @@ using namespace sensors;
 
 class ignition::sensors::BrownDistortionModelPrivate
 {
-  /// \brief If type starts with BROWN, the mean of the distribution
-  /// from which we sample when adding noise.
+  /// \brief The radial distortion coefficient k1.
   public: double k1 = 0.0;
 
-  /// \brief If type starts with BROWN, the standard deviation of the
-  /// distribution from which we sample when adding noise.
+  /// \brief The radial distortion coefficient k2.
   public: double k2 = 0.0;
 
-  /// \brief If type starts with BROWN, the bias we'll add.
+  /// \brief The radial distortion coefficient k3.
   public: double k3 = 0.0;
 
-  /// \brief If type starts with BROWN, the standard deviation of the
-  /// distribution from which the dynamic bias will be driven.
+  /// \brief The radial distortion coefficient p1.
   public: double p1 = 0.0;
 
-  /// \brief If type starts with BROWN, the correlation time of the
-  /// process from which the dynamic bias will be driven.
+  /// \brief The radial distortion coefficient p2.
   public: double p2 = 0.0;
 
-  /// \brief If type==BROWN_QUANTIZED, the precision to which
-  /// the output signal is rounded.
+  /// \brief The distortion center.
   public: math::Vector2d lensCenter = {0.5, 0.5};
 };
 
 //////////////////////////////////////////////////
 BrownDistortionModel::BrownDistortionModel()
-  : Distortion(DistortionType::BROWN), dataPtr(new BrownDistortionModelPrivate())
+  : Distortion(DistortionType::BROWN),
+    dataPtr(new BrownDistortionModelPrivate())
 {
 }
 
@@ -120,9 +116,10 @@ math::Vector2d BrownDistortionModel::Center() const
 //////////////////////////////////////////////////
 void BrownDistortionModel::Print(std::ostream &_out) const
 {
-  // _out << "Gaussian noise, mean[" << this->dataPtr->mean << "], "
-  //   << "stdDev[" << this->dataPtr->stdDev << "] "
-  //   << "bias[" << this->dataPtr->bias << "] "
-  //   << "precision[" << this->dataPtr->precision << "] "
-  //   << "quantized[" << this->dataPtr->quantized << "]";
+  _out << "Distortion, k1[" << this->dataPtr->k1 << "], "
+    << "k2[" << this->dataPtr->k2 << "] "
+    << "k3[" << this->dataPtr->k2 << "] "
+    << "p1[" << this->dataPtr->p1 << "] "
+    << "p2[" << this->dataPtr->p2 << "] "
+    << "lensCenter[" << this->dataPtr->lensCenter << "]";
 }

--- a/src/BrownDistortionModel.cc
+++ b/src/BrownDistortionModel.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifdef _WIN32
+  // Ensure that Winsock2.h is included before Windows.h, which can get
+  // pulled in by anybody (e.g., Boost).
+  #include <Winsock2.h>
+#endif
+
+#include "ignition/sensors/BrownDistortionModel.hh"
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Rand.hh>
+
+#include "ignition/common/Console.hh"
+
+using namespace ignition;
+using namespace sensors;
+
+class ignition::sensors::BrownDistortionModelPrivate
+{
+  /// \brief If type starts with BROWN, the mean of the distribution
+  /// from which we sample when adding noise.
+  public: double k1 = 0.0;
+
+  /// \brief If type starts with BROWN, the standard deviation of the
+  /// distribution from which we sample when adding noise.
+  public: double k2 = 0.0;
+
+  /// \brief If type starts with BROWN, the bias we'll add.
+  public: double k3 = 0.0;
+
+  /// \brief If type starts with BROWN, the standard deviation of the
+  /// distribution from which the dynamic bias will be driven.
+  public: double p1 = 0.0;
+
+  /// \brief If type starts with BROWN, the correlation time of the
+  /// process from which the dynamic bias will be driven.
+  public: double p2 = 0.0;
+
+  /// \brief If type==BROWN_QUANTIZED, the precision to which
+  /// the output signal is rounded.
+  public: math::Vector2d lensCenter = {0.5, 0.5};
+};
+
+//////////////////////////////////////////////////
+GaussianNoiseModel::GaussianNoiseModel()
+  : Noise(NoiseType::GAUSSIAN), dataPtr(new GaussianNoiseModelPrivate())
+{
+}
+
+//////////////////////////////////////////////////
+GaussianNoiseModel::~GaussianNoiseModel()
+{
+  delete this->dataPtr;
+  this->dataPtr = nullptr;
+}
+
+//////////////////////////////////////////////////
+void GaussianNoiseModel::Load(const sdf::Noise &_sdf)
+{
+  Noise::Load(_sdf);
+  std::ostringstream out;
+
+  this->dataPtr->mean = _sdf.Mean();
+  this->dataPtr->stdDev = _sdf.StdDev();
+  this->dataPtr->dynamicBiasStdDev = _sdf.DynamicBiasStdDev();
+  this->dataPtr->dynamicBiasCorrTime = _sdf.DynamicBiasCorrelationTime();
+
+  // Sample the bias
+  double biasMean = 0;
+  double biasStdDev = 0;
+  biasMean = _sdf.BiasMean();
+  biasStdDev = _sdf.BiasStdDev();
+  this->dataPtr->bias = ignition::math::Rand::DblNormal(biasMean, biasStdDev);
+
+  // With equal probability, we pick a negative bias (by convention,
+  // rateBiasMean should be positive, though it would work fine if
+  // negative).
+  if (ignition::math::Rand::DblUniform() < 0.5)
+    this->dataPtr->bias = -this->dataPtr->bias;
+
+  this->Print(out);
+
+  this->dataPtr->precision = _sdf.Precision();
+  if (this->dataPtr->precision < 0)
+    ignerr << "Noise precision cannot be less than 0" << std::endl;
+  else if (!ignition::math::equal(this->dataPtr->precision, 0.0, 1e-6))
+    this->dataPtr->quantized = true;
+}
+
+//////////////////////////////////////////////////
+double GaussianNoiseModel::ApplyImpl(double _in, double _dt)
+{
+  // Generate independent (uncorrelated) Gaussian noise to each input value.
+  double whiteNoise = ignition::math::Rand::DblNormal(
+      this->dataPtr->mean, this->dataPtr->stdDev);
+
+  // Generate varying (correlated) bias to each input value.
+  // This implementation is based on the one available in Rotors:
+  // https://github.com/ethz-asl/rotors_simulator/blob/master/rotors_gazebo_plugins/src/gazebo_imu_plugin.cpp
+  //
+  // More information about the parameters and their derivation:
+  //
+  // https://github.com/ethz-asl/kalibr/wiki/IMU-Noise-Model
+  //
+  // This can only be generated in the case that _dt > 0.0
+
+  if (this->dataPtr->dynamicBiasStdDev > 0 &&
+     this->dataPtr->dynamicBiasCorrTime > 0 &&
+     _dt > 0)
+  {
+    double sigma_b = this->dataPtr->dynamicBiasStdDev;
+    double tau = this->dataPtr->dynamicBiasCorrTime;
+
+    double sigma_b_d = sqrt(-sigma_b * sigma_b *
+        tau / 2 * expm1(-2 * _dt / tau));
+    double phi_d = exp(-_dt / tau);
+    this->dataPtr->bias = phi_d * this->dataPtr->bias +
+      ignition::math::Rand::DblNormal(0, sigma_b_d);
+  }
+
+  double output = _in + this->dataPtr->bias + whiteNoise;
+
+  if (this->dataPtr->quantized)
+  {
+    // Apply this->dataPtr->precision
+    if (!ignition::math::equal(this->dataPtr->precision, 0.0, 1e-6))
+    {
+      output = std::round(output / this->dataPtr->precision) *
+        this->dataPtr->precision;
+    }
+  }
+  return output;
+}
+
+//////////////////////////////////////////////////
+double GaussianNoiseModel::Mean() const
+{
+  return this->dataPtr->mean;
+}
+
+//////////////////////////////////////////////////
+double GaussianNoiseModel::StdDev() const
+{
+  return this->dataPtr->stdDev;
+}
+
+//////////////////////////////////////////////////
+double GaussianNoiseModel::Bias() const
+{
+  return this->dataPtr->bias;
+}
+
+//////////////////////////////////////////////////
+void GaussianNoiseModel::Print(std::ostream &_out) const
+{
+  _out << "Gaussian noise, mean[" << this->dataPtr->mean << "], "
+    << "stdDev[" << this->dataPtr->stdDev << "] "
+    << "bias[" << this->dataPtr->bias << "] "
+    << "precision[" << this->dataPtr->precision << "] "
+    << "quantized[" << this->dataPtr->quantized << "]";
+}

--- a/src/BrownDistortionModel.cc
+++ b/src/BrownDistortionModel.cc
@@ -21,15 +21,15 @@
 #endif
 
 #include "ignition/sensors/BrownDistortionModel.hh"
+
+#include <ignition/common/Console.hh>
 #include <ignition/math/Helpers.hh>
 #include <ignition/math/Rand.hh>
-
-#include "ignition/common/Console.hh"
 
 using namespace ignition;
 using namespace sensors;
 
-class ignition::sensors::BrownDistortionModelPrivate
+class ignition::sensors::BrownDistortionModel::Implementation
 {
   /// \brief The radial distortion coefficient k1.
   public: double k1 = 0.0;
@@ -53,15 +53,13 @@ class ignition::sensors::BrownDistortionModelPrivate
 //////////////////////////////////////////////////
 BrownDistortionModel::BrownDistortionModel()
   : Distortion(DistortionType::BROWN),
-    dataPtr(new BrownDistortionModelPrivate())
+    dataPtr(utils::MakeImpl<Implementation>())
 {
 }
 
 //////////////////////////////////////////////////
 BrownDistortionModel::~BrownDistortionModel()
 {
-  delete this->dataPtr;
-  this->dataPtr = nullptr;
 }
 
 //////////////////////////////////////////////////
@@ -117,9 +115,9 @@ math::Vector2d BrownDistortionModel::Center() const
 void BrownDistortionModel::Print(std::ostream &_out) const
 {
   _out << "Distortion, k1[" << this->dataPtr->k1 << "], "
-    << "k2[" << this->dataPtr->k2 << "] "
-    << "k3[" << this->dataPtr->k2 << "] "
-    << "p1[" << this->dataPtr->p1 << "] "
-    << "p2[" << this->dataPtr->p2 << "] "
-    << "lensCenter[" << this->dataPtr->lensCenter << "]";
+      << "k2[" << this->dataPtr->k2 << "] "
+      << "k3[" << this->dataPtr->k2 << "] "
+      << "p1[" << this->dataPtr->p1 << "] "
+      << "p2[" << this->dataPtr->p2 << "] "
+      << "lensCenter[" << this->dataPtr->lensCenter << "]";
 }

--- a/src/BrownDistortionModel.cc
+++ b/src/BrownDistortionModel.cc
@@ -72,7 +72,6 @@ BrownDistortionModel::~BrownDistortionModel()
 void BrownDistortionModel::Load(const sdf::Camera &_sdf)
 {
   Distortion::Load(_sdf);
-  std::ostringstream out;
 
   this->dataPtr->k1 = _sdf.DistortionK1();
   this->dataPtr->k2 = _sdf.DistortionK2();
@@ -80,8 +79,6 @@ void BrownDistortionModel::Load(const sdf::Camera &_sdf)
   this->dataPtr->p1 = _sdf.DistortionP1();
   this->dataPtr->p2 = _sdf.DistortionP2();
   this->dataPtr->lensCenter = _sdf.DistortionCenter();
-
-  this->Print(out);
 }
 
 //////////////////////////////////////////////////

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@ set (sources
   Sensor.cc
   Noise.cc
   GaussianNoiseModel.cc
+  Distortion.cc
+  BrownDistortionModel.cc
   PointCloudUtil.cc
   SensorFactory.cc
   SensorTypes.cc
@@ -14,6 +16,7 @@ set(rendering_sources
   RenderingEvents.cc
   ImageGaussianNoiseModel.cc
   ImageNoise.cc
+  ImageDistortion.cc
 )
 
 set (gtest_sources

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(rendering_sources
   RenderingEvents.cc
   ImageGaussianNoiseModel.cc
   ImageNoise.cc
+  ImageBrownDistortionModel.cc
   ImageDistortion.cc
 )
 

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -36,6 +36,7 @@
 #include <ignition/transport/Node.hh>
 
 #include "ignition/sensors/CameraSensor.hh"
+#include "ignition/sensors/ImageBrownDistortionModel.hh"
 #include "ignition/sensors/ImageGaussianNoiseModel.hh"
 #include "ignition/sensors/ImageNoise.hh"
 #include "ignition/sensors/Manager.hh"

--- a/src/Distortion.cc
+++ b/src/Distortion.cc
@@ -44,7 +44,7 @@ class ignition::sensors::DistortionPrivate
 DistortionPtr DistortionFactory::NewDistortionModel(const sdf::Camera &_sdf,
     const std::string &_sensorType)
 {
-  // TODO support different distortion models
+  // TODO(WilliamLewww): support different distortion models
   DistortionType distortionType = DistortionType::BROWN;
 
   DistortionPtr distortion;
@@ -90,7 +90,8 @@ DistortionPtr DistortionFactory::NewDistortionModel(const sdf::Camera &_sdf,
 DistortionPtr DistortionFactory::NewDistortionModel(sdf::ElementPtr _sdf,
     const std::string &_sensorType)
 {
-  // TODO create a distortion SDF to support different distortion models
+  // TODO(WilliamLewww): create a distortion SDF to support different
+  // distortion models
   IGN_ASSERT(_sdf != nullptr, "camera sdf is null");
   IGN_ASSERT(_sdf->GetName() == "camera", "Not a camera SDF element");
   sdf::Camera cameraDom;

--- a/src/Distortion.cc
+++ b/src/Distortion.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifdef _WIN32
+  // Ensure that Winsock2.h is included before Windows.h, which can get
+  // pulled in by anybody (e.g., Boost).
+  #include <Winsock2.h>
+#endif
+
+#include <functional>
+
+#include <ignition/common/Console.hh>
+
+#include "ignition/sensors/BrownDistortionModel.hh"
+#include "ignition/sensors/Distortion.hh"
+
+using namespace ignition;
+using namespace sensors;
+
+class ignition::sensors::DistortionPrivate
+{
+  /// \brief Which type of distortion we're applying
+  public: DistortionType type = DistortionType::NONE;
+
+  /// \brief Camera sdf element.
+  public: sdf::Camera cameraDom;
+};
+
+//////////////////////////////////////////////////
+DistortionPtr DistortionFactory::NewDistortionModel(const sdf::Camera &_sdf,
+    const std::string &_sensorType)
+{
+  // TODO support different distortion models
+  DistortionType distortionType = DistortionType::BROWN;
+
+  DistortionPtr distortion;
+
+  // Check for 'brown' distortion.
+  if (distortionType == DistortionType::BROWN)
+  {
+    if (_sensorType == "camera" || _sensorType == "depth" ||
+        _sensorType == "multicamera" || _sensorType == "wideanglecamera" ||
+        _sensorType == "thermal_camera" || _sensorType == "rgbd_camera")
+    {
+      ignerr << "Image distortion requested. "
+             << "Please use ImageDistortionFactory::DistortionModel instead"
+             << std::endl;
+      return distortion;
+    }
+    else
+      distortion.reset(new BrownDistortionModel());
+
+    IGN_ASSERT(distortion->Type() == DistortionType::BROWN,
+        "Distortion type should be 'brown'");
+  }
+  else if (distortionType == DistortionType::NONE)
+  {
+    // Return empty distortion if 'none' or 'custom' is specified.
+    // if 'custom', the type will be set once the user calls the
+    // SetCustomDistortionCallback function.
+    distortion.reset(new Distortion(DistortionType::NONE));
+    IGN_ASSERT(distortion->Type() == DistortionType::NONE,
+        "Distortion type should be 'none'");
+  }
+  else
+  {
+    ignerr << "Unrecognized distortion type" << std::endl;
+    return DistortionPtr();
+  }
+  distortion->Load(_sdf);
+
+  return distortion;
+}
+
+//////////////////////////////////////////////////
+DistortionPtr DistortionFactory::NewDistortionModel(sdf::ElementPtr _sdf,
+    const std::string &_sensorType)
+{
+  // TODO create a distortion SDF to support different distortion models
+  IGN_ASSERT(_sdf != nullptr, "camera sdf is null");
+  IGN_ASSERT(_sdf->GetName() == "camera", "Not a camera SDF element");
+  sdf::Camera cameraDom;
+  cameraDom.Load(_sdf);
+
+  return NewDistortionModel(cameraDom, _sensorType);
+}
+
+//////////////////////////////////////////////////
+Distortion::Distortion(DistortionType _type)
+  : dataPtr(new DistortionPrivate())
+{
+  this->dataPtr->type = _type;
+}
+
+//////////////////////////////////////////////////
+Distortion::~Distortion()
+{
+  delete this->dataPtr;
+  this->dataPtr = nullptr;
+}
+
+//////////////////////////////////////////////////
+void Distortion::Load(const sdf::Camera &_sdf)
+{
+  this->dataPtr->cameraDom = _sdf;
+}
+
+//////////////////////////////////////////////////
+DistortionType Distortion::Type() const
+{
+  return this->dataPtr->type;
+}
+
+//////////////////////////////////////////////////
+void Distortion::Print(std::ostream &_out) const
+{
+  _out << "Distortion with type[" << static_cast<int>(this->dataPtr->type)
+    << "] "
+    << "does not have an overloaded Print function. "
+    << "No more information is available.";
+}

--- a/src/Distortion.cc
+++ b/src/Distortion.cc
@@ -31,7 +31,7 @@
 using namespace ignition;
 using namespace sensors;
 
-class ignition::sensors::DistortionPrivate
+class ignition::sensors::Distortion::Implementation
 {
   /// \brief Which type of distortion we're applying
   public: DistortionType type = DistortionType::NONE;
@@ -102,7 +102,7 @@ DistortionPtr DistortionFactory::NewDistortionModel(sdf::ElementPtr _sdf,
 
 //////////////////////////////////////////////////
 Distortion::Distortion(DistortionType _type)
-  : dataPtr(new DistortionPrivate())
+  : dataPtr(utils::MakeImpl<Implementation>())
 {
   this->dataPtr->type = _type;
 }
@@ -110,8 +110,6 @@ Distortion::Distortion(DistortionType _type)
 //////////////////////////////////////////////////
 Distortion::~Distortion()
 {
-  delete this->dataPtr;
-  this->dataPtr = nullptr;
 }
 
 //////////////////////////////////////////////////
@@ -130,7 +128,7 @@ DistortionType Distortion::Type() const
 void Distortion::Print(std::ostream &_out) const
 {
   _out << "Distortion with type[" << static_cast<int>(this->dataPtr->type)
-    << "] "
-    << "does not have an overloaded Print function. "
-    << "No more information is available.";
+      << "] "
+      << "does not have an overloaded Print function. "
+      << "No more information is available.";
 }

--- a/src/Distortion.cc
+++ b/src/Distortion.cc
@@ -52,9 +52,7 @@ DistortionPtr DistortionFactory::NewDistortionModel(const sdf::Camera &_sdf,
   // Check for 'brown' distortion.
   if (distortionType == DistortionType::BROWN)
   {
-    if (_sensorType == "camera" || _sensorType == "depth" ||
-        _sensorType == "multicamera" || _sensorType == "wideanglecamera" ||
-        _sensorType == "thermal_camera" || _sensorType == "rgbd_camera")
+    if (_sensorType == "camera")
     {
       ignerr << "Image distortion requested. "
              << "Please use ImageDistortionFactory::DistortionModel instead"

--- a/src/ImageBrownDistortionModel.cc
+++ b/src/ImageBrownDistortionModel.cc
@@ -84,12 +84,16 @@ ImageBrownDistortionModel::~ImageBrownDistortionModel()
 }
 
 //////////////////////////////////////////////////
-void ImageBrownDistortionModel::Load(const sdf::Noise &_sdf)
+void ImageBrownDistortionModel::Load(const sdf::Camera &_sdf)
 {
-  Noise::Load(_sdf);
+  Distortion::Load(_sdf);
 
-  this->dataPtr->mean = _sdf.Mean();
-  this->dataPtr->stdDev = _sdf.StdDev();
+  this->dataPtr->k1 = _sdf.DistortionK1();
+  this->dataPtr->k2 = _sdf.DistortionK2();
+  this->dataPtr->k3 = _sdf.DistortionK3();
+  this->dataPtr->p1 = _sdf.DistortionP1();
+  this->dataPtr->p2 = _sdf.DistortionP2();
+  this->dataPtr->lensCenter = _sdf.DistortionCenter();
 }
 
 //////////////////////////////////////////////////
@@ -106,20 +110,24 @@ void ImageBrownDistortionModel::SetCamera(rendering::CameraPtr _camera)
   if (rpSystem)
   {
     // add gaussian noise pass
-    rendering::RenderPassPtr noisePass =
-      rpSystem->Create<rendering::BrownDistortionPass>();
-    this->dataPtr->gaussianNoisePass =
-        std::dynamic_pointer_cast<rendering::BrownDistortionPass>(noisePass);
-    this->dataPtr->gaussianNoisePass->SetMean(this->dataPtr->mean);
-    this->dataPtr->gaussianNoisePass->SetStdDev(this->dataPtr->stdDev);
-    this->dataPtr->gaussianNoisePass->SetEnabled(true);
-    _camera->AddRenderPass(this->dataPtr->gaussianNoisePass);
+    rendering::RenderPassPtr distortionPass =
+      rpSystem->Create<rendering::DistortionPass>();
+    this->dataPtr->distortionPass =
+        std::dynamic_pointer_cast<rendering::DistortionPass>(distortionPass);
+    this->dataPtr->distortionPass->SetK1(this->dataPtr->k1);
+    this->dataPtr->distortionPass->SetK2(this->dataPtr->k2);
+    this->dataPtr->distortionPass->SetK3(this->dataPtr->k3);
+    this->dataPtr->distortionPass->SetP1(this->dataPtr->p1);
+    this->dataPtr->distortionPass->SetP2(this->dataPtr->p2);
+    this->dataPtr->distortionPass->SetCenter(this->dataPtr->lensCenter);
+    this->dataPtr->distortionPass->SetEnabled(true);
+    _camera->AddRenderPass(this->dataPtr->distortionPass);
   }
 }
 
 //////////////////////////////////////////////////
 void ImageBrownDistortionModel::Print(std::ostream &_out) const
 {
-  _out << "Image Gaussian noise, mean[" << this->dataPtr->mean << "], "
-    << "stdDev[" << this->dataPtr->stdDev << "] ";
+  // _out << "Image Gaussian noise, mean[" << this->dataPtr->mean << "], "
+  //   << "stdDev[" << this->dataPtr->stdDev << "] ";
 }

--- a/src/ImageBrownDistortionModel.cc
+++ b/src/ImageBrownDistortionModel.cc
@@ -22,7 +22,7 @@
 
 #include <ignition/common/Console.hh>
 
-// TODO Remove these pragmas once ign-rendering is disabling the
+// TODO(WilliamLewww): Remove these pragmas once ign-rendering is disabling the
 // warnings
 #ifdef _WIN32
 #pragma warning(push)
@@ -43,30 +43,25 @@ using namespace sensors;
 
 class ignition::sensors::ImageBrownDistortionModelPrivate
 {
-  /// \brief If type starts with BROWN, the mean of the distribution
-  /// from which we sample when adding noise.
+  /// \brief The radial distortion coefficient k1.
   public: double k1 = 0.0;
 
-  /// \brief If type starts with BROWN, the standard deviation of the
-  /// distribution from which we sample when adding noise.
+  /// \brief The radial distortion coefficient k2.
   public: double k2 = 0.0;
 
-  /// \brief If type starts with BROWN, the bias we'll add.
+  /// \brief The radial distortion coefficient k3.
   public: double k3 = 0.0;
 
-  /// \brief If type starts with BROWN, the standard deviation of the
-  /// distribution from which the dynamic bias will be driven.
+  /// \brief The radial distortion coefficient p1.
   public: double p1 = 0.0;
 
-  /// \brief If type starts with BROWN, the correlation time of the
-  /// process from which the dynamic bias will be driven.
+  /// \brief The radial distortion coefficient p2.
   public: double p2 = 0.0;
 
-  /// \brief If type==BROWN_QUANTIZED, the precision to which
-  /// the output signal is rounded.
+  /// \brief The distortion center.
   public: math::Vector2d lensCenter = {0.5, 0.5};
 
-  /// \brief Gaussian noise pass.
+  /// \brief The distortion pass.
   public: rendering::DistortionPassPtr distortionPass;
 };
 
@@ -101,7 +96,7 @@ void ImageBrownDistortionModel::SetCamera(rendering::CameraPtr _camera)
 {
   if (!_camera)
   {
-    ignerr << "Unable to apply gaussian noise, camera is null\n";
+    ignerr << "Unable to apply distortion, camera is null\n";
     return;
   }
 
@@ -109,7 +104,7 @@ void ImageBrownDistortionModel::SetCamera(rendering::CameraPtr _camera)
   rendering::RenderPassSystemPtr rpSystem = engine->RenderPassSystem();
   if (rpSystem)
   {
-    // add gaussian noise pass
+    // add distortion pass
     rendering::RenderPassPtr distortionPass =
       rpSystem->Create<rendering::DistortionPass>();
     this->dataPtr->distortionPass =
@@ -128,6 +123,10 @@ void ImageBrownDistortionModel::SetCamera(rendering::CameraPtr _camera)
 //////////////////////////////////////////////////
 void ImageBrownDistortionModel::Print(std::ostream &_out) const
 {
-  // _out << "Image Gaussian noise, mean[" << this->dataPtr->mean << "], "
-  //   << "stdDev[" << this->dataPtr->stdDev << "] ";
+  _out << "Image distortion, k1[" << this->dataPtr->k1 << "], "
+    << "k2[" << this->dataPtr->k2 << "] "
+    << "k3[" << this->dataPtr->k2 << "] "
+    << "p1[" << this->dataPtr->p1 << "] "
+    << "p2[" << this->dataPtr->p2 << "] "
+    << "lensCenter[" << this->dataPtr->lensCenter << "]";
 }

--- a/src/ImageBrownDistortionModel.cc
+++ b/src/ImageBrownDistortionModel.cc
@@ -29,8 +29,8 @@
 #pragma warning(disable: 4251)
 #endif
 #include <ignition/rendering/DistortionPass.hh>
-#include <ignition/rendering/RenderPass.hh>
 #include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderPass.hh>
 #include <ignition/rendering/RenderPassSystem.hh>
 #ifdef _WIN32
 #pragma warning(pop)
@@ -124,9 +124,9 @@ void ImageBrownDistortionModel::SetCamera(rendering::CameraPtr _camera)
 void ImageBrownDistortionModel::Print(std::ostream &_out) const
 {
   _out << "Image distortion, k1[" << this->dataPtr->k1 << "], "
-    << "k2[" << this->dataPtr->k2 << "] "
-    << "k3[" << this->dataPtr->k2 << "] "
-    << "p1[" << this->dataPtr->p1 << "] "
-    << "p2[" << this->dataPtr->p2 << "] "
-    << "lensCenter[" << this->dataPtr->lensCenter << "]";
+      << "k2[" << this->dataPtr->k2 << "] "
+      << "k3[" << this->dataPtr->k2 << "] "
+      << "p1[" << this->dataPtr->p1 << "] "
+      << "p2[" << this->dataPtr->p2 << "] "
+      << "lensCenter[" << this->dataPtr->lensCenter << "]";
 }

--- a/src/ImageDistortion.cc
+++ b/src/ImageDistortion.cc
@@ -76,7 +76,8 @@ DistortionPtr ImageDistortionFactory::NewDistortionModel(
 DistortionPtr ImageDistortionFactory::NewDistortionModel(sdf::ElementPtr _sdf,
     const std::string &_sensorType)
 {
-  // TODO create a distortion SDF to support different distortion models
+  // TODO(WilliamLewww): create a distortion SDF to support different
+  // distortion models
   IGN_ASSERT(_sdf != nullptr, "camera sdf is null");
   IGN_ASSERT(_sdf->GetName() == "camera", "Not a camera SDF element");
   sdf::Camera cameraDom;

--- a/src/ImageDistortion.cc
+++ b/src/ImageDistortion.cc
@@ -41,9 +41,7 @@ DistortionPtr ImageDistortionFactory::NewDistortionModel(
   // Check for 'brown' distortion.
   if (distortionType == DistortionType::BROWN)
   {
-    if (_sensorType == "camera" || _sensorType == "depth" ||
-        _sensorType == "multicamera" || _sensorType == "wideanglecamera" ||
-        _sensorType == "thermal_camera" ||  _sensorType == "rgbd_camera")
+    if (_sensorType == "camera")
     {
       distortion.reset(new ImageBrownDistortionModel());
     }

--- a/src/ImageDistortion.cc
+++ b/src/ImageDistortion.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifdef _WIN32
+  // Ensure that Winsock2.h is included before Windows.h, which can get
+  // pulled in by anybody (e.g., Boost).
+  #include <Winsock2.h>
+#endif
+
+#include "ignition/common/Console.hh"
+
+#include "ignition/sensors/ImageDistortion.hh"
+#include "ignition/sensors/ImageBrownDistortionModel.hh"
+
+using namespace ignition;
+using namespace sensors;
+
+//////////////////////////////////////////////////
+DistortionPtr ImageDistortionFactory::NewDistortionModel(
+    const sdf::Camera &_sdf,
+    const std::string &_sensorType)
+{
+  DistortionType distortionType = DistortionType::BROWN;
+
+  DistortionPtr distortion;
+
+  // Check for 'brown' distortion.
+  if (distortionType == DistortionType::BROWN)
+  {
+    if (_sensorType == "camera" || _sensorType == "depth" ||
+        _sensorType == "multicamera" || _sensorType == "wideanglecamera" ||
+        _sensorType == "thermal_camera" ||  _sensorType == "rgbd_camera")
+    {
+      distortion.reset(new ImageBrownDistortionModel());
+    }
+    else
+      distortion.reset(new BrownDistortionModel());
+
+    IGN_ASSERT(distortion->Type() == DistortionType::BROWN,
+        "Distortion type should be 'brown'");
+  }
+  else if (distortionType == DistortionType::NONE)
+  {
+    // Return empty distortion if 'none' or 'custom' is specified.
+    // if 'custom', the type will be set once the user calls the
+    // SetCustomDistortionCallback function.
+    distortion.reset(new Distortion(DistortionType::NONE));
+    IGN_ASSERT(distortion->Type() == DistortionType::NONE,
+        "Distortion type should be 'none'");
+  }
+  else
+  {
+    ignerr << "Unrecognized distortion type" << std::endl;
+    return DistortionPtr();
+  }
+  distortion->Load(_sdf);
+
+  return distortion;
+}
+
+//////////////////////////////////////////////////
+DistortionPtr ImageDistortionFactory::NewDistortionModel(sdf::ElementPtr _sdf,
+    const std::string &_sensorType)
+{
+  // TODO create a distortion SDF to support different distortion models
+  IGN_ASSERT(_sdf != nullptr, "camera sdf is null");
+  IGN_ASSERT(_sdf->GetName() == "camera", "Not a camera SDF element");
+  sdf::Camera cameraDom;
+  cameraDom.Load(_sdf);
+
+  return NewDistortionModel(cameraDom, _sensorType);
+}

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_TYPE "INTEGRATION")
 
 set(dri_tests
+  camera.cc
   depth_camera.cc
   distortion_camera.cc
   gpu_lidar_sensor.cc

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(TEST_TYPE "INTEGRATION")
 
 set(dri_tests
-  camera.cc
   depth_camera.cc
+  distortion_camera.cc
   gpu_lidar_sensor.cc
   rgbd_camera.cc
   thermal_camera.cc

--- a/test/integration/distortion_camera.cc
+++ b/test/integration/distortion_camera.cc
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2017 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <ignition/common/Console.hh>
+#include <ignition/common/Filesystem.hh>
+#include <ignition/sensors/Manager.hh>
+#include <ignition/sensors/CameraSensor.hh>
+
+// TODO(WilliamLewww): Remove these pragmas once ign-rendering is disabling the
+// warnings
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/rendering/RenderEngine.hh>
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
+
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable: 4005)
+#pragma warning(disable: 4251)
+#endif
+#include <ignition/msgs.hh>
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
+
+#include "test_config.h"  // NOLINT(build/include)
+#include "TransportTestTools.hh"
+
+class DistortionCameraSensorTest: public testing::Test,
+  public testing::WithParamInterface<const char *>
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
+
+  // Create a Camera sensor from a SDF and gets a image message
+  public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
+};
+
+void DistortionCameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
+{
+  // get the darn test data
+  std::string path = ignition::common::joinPaths(PROJECT_SOURCE_PATH, "test",
+      "sdf", "distortion_camera_sensor_builtin.sdf");
+  sdf::SDFPtr doc(new sdf::SDF());
+  sdf::init(doc);
+  ASSERT_TRUE(sdf::readFile(path, doc));
+  ASSERT_NE(nullptr, doc->Root());
+  ASSERT_TRUE(doc->Root()->HasElement("model"));
+  auto modelPtr = doc->Root()->GetElement("model");
+  ASSERT_TRUE(modelPtr->HasElement("link"));
+  auto linkPtr = modelPtr->GetElement("link");
+  ASSERT_TRUE(linkPtr->HasElement("sensor"));
+  auto sensorPtr = linkPtr->GetElement("sensor");
+
+  if (_renderEngine == "ogre2")
+  {
+    igndbg << "Distortion camera not supported yet in rendering engine: "
+            << _renderEngine << std::endl;
+    return;
+  }
+
+  // Setup ign-rendering with an empty scene
+  auto *engine = ignition::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+
+  ignition::rendering::ScenePtr scene = engine->CreateScene("scene");
+
+  // do the test
+  ignition::sensors::Manager mgr;
+
+  ignition::sensors::CameraSensor *sensor =
+      mgr.CreateSensor<ignition::sensors::CameraSensor>(sensorPtr);
+  ASSERT_NE(sensor, nullptr);
+  sensor->SetScene(scene);
+
+  ASSERT_NE(sensor->RenderingCamera(), nullptr);
+  EXPECT_NE(sensor->Id(), sensor->RenderingCamera()->Id());
+  EXPECT_EQ(256u, sensor->ImageWidth());
+  EXPECT_EQ(257u, sensor->ImageHeight());
+
+  std::string topic =
+      "/test/integration/DistortionCameraPlugin_imagesWithBuiltinSDF";
+  WaitForMessageTestHelper<ignition::msgs::Image> helper(topic);
+
+  // Update once to create image
+  mgr.RunOnce(std::chrono::steady_clock::duration::zero());
+
+  EXPECT_TRUE(helper.WaitForMessage()) << helper;
+
+  // test removing sensor
+  // first make sure the sensor objects do exist
+  auto sensorId = sensor->Id();
+  auto cameraId = sensor->RenderingCamera()->Id();
+  EXPECT_EQ(sensor, mgr.Sensor(sensorId));
+  EXPECT_EQ(sensor->RenderingCamera(), scene->SensorById(cameraId));
+  // remove and check sensor objects no longer exist in both sensors and
+  // rendering
+  EXPECT_TRUE(mgr.Remove(sensorId));
+  EXPECT_EQ(nullptr, mgr.Sensor(sensorId));
+  EXPECT_EQ(nullptr, scene->SensorById(cameraId));
+
+  // Clean up
+  engine->DestroyScene(scene);
+  ignition::rendering::unloadEngine(engine->Name());
+}
+
+//////////////////////////////////////////////////
+TEST_P(DistortionCameraSensorTest, ImagesWithBuiltinSDF)
+{
+  ImagesWithBuiltinSDF(GetParam());
+}
+
+INSTANTIATE_TEST_CASE_P(DistortionCameraSensor, DistortionCameraSensorTest,
+    RENDER_ENGINE_VALUES, ignition::rendering::PrintToStringParam());
+
+//////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  ignition::common::Console::SetVerbosity(4);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/integration/distortion_camera.cc
+++ b/test/integration/distortion_camera.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,8 @@ class DistortionCameraSensorTest: public testing::Test,
   public: void ImagesWithBuiltinSDF(const std::string &_renderEngine);
 };
 
-void DistortionCameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
+void DistortionCameraSensorTest::ImagesWithBuiltinSDF(
+    const std::string &_renderEngine)
 {
   // get the darn test data
   std::string path = ignition::common::joinPaths(PROJECT_SOURCE_PATH, "test",

--- a/test/sdf/distortion_camera_sensor_builtin.sdf
+++ b/test/sdf/distortion_camera_sensor_builtin.sdf
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="m1">
+    <link name="link1">
+      <sensor name='distortion_camera' type='camera'>
+        <visualize>1</visualize>
+        <camera>
+          <horizontal_fov>0.927295218</horizontal_fov>
+          <image>
+            <width>256</width>
+            <height>257</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <distortion>
+            <k1>-0.1349</k1>
+            <k2>-0.51868</k2>
+            <k3>-0.001</k3>
+            <p1>0</p1>
+            <p2>0</p2>
+            <center>0.5 0.5</center>
+          </distortion>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <topic>/test/integration/DistortionCameraPlugin_imagesWithBuiltinSDF</topic>
+      </sensor>
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION
# 🎉 Distortion Camera Sensor

## Summary
Camera distortion has already been implemented in ign-rendering, but in order to use it with ign-gazebo, it must be implemented within ign-sensors.

Distortion is implemented with abstraction (just like how noise is implemented) in  the case that different distortion models are to be implemented. The abstract implementation in ign-sensors would reduce future work for adding additional distortions.

Comments with the `TODO` tag have been added in areas where additional work is required in other repositories to maintain the abstraction. For example, sdf::Distortion does not exist so sdf::Camera is being used instead with it's distortion  element that is hard-coded with the Brown's distortion model coefficients.

### Tasks required to enable distortion abstraction
- [ ] Change [DistortionPass](https://github.com/ignitionrobotics/ign-rendering/blob/ign-rendering6/include/ignition/rendering/DistortionPass.hh) to BrownDistortionPass in ign-rendering
- [ ] Create sdf::Distortion class in sdformat
- [ ] Update ign-sensors to use the new classes

## Test it
Requires the branch: https://github.com/WilliamLewww/ign-gazebo/tree/wlew/distortion_test
`ign gazebo ign-gazebo/test/worlds/camera_distortion.sdf`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.