### PR TITLE
Conform to ros format for header field frame_id of sensor msgs

### DIFF
--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -138,6 +138,10 @@ namespace ignition
       /// \return Name of sensor.
       public: std::string Name() const;
 
+      /// \brief FrameID.
+      /// \return FrameID of sensor.
+      public: std::string FrameID() const;
+
       /// \brief Get topic where sensor data is published.
       /// \return Topic sensor publishes data to
       public: std::string Topic() const;

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -138,9 +138,13 @@ namespace ignition
       /// \return Name of sensor.
       public: std::string Name() const;
 
-      /// \brief FrameID.
-      /// \return FrameID of sensor.
-      public: std::string FrameID() const;
+      /// \brief FrameId.
+      /// \return FrameId of sensor.
+      public: std::string FrameId() const;
+
+      /// \brief Set Frame ID of the sensor
+      /// \param[in] _frameId Frame ID of the sensor
+      public: void SetFrameId(const std::string &_frameId);
 
       /// \brief Get topic where sensor data is published.
       /// \return Topic sensor publishes data to

--- a/src/AirPressureSensor.cc
+++ b/src/AirPressureSensor.cc
@@ -159,7 +159,7 @@ bool AirPressureSensor::Update(const ignition::common::Time &_now)
   msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->Name());
+  frame->add_value(this->FrameID());
 
   // This block of code comes from RotorS:
   // https://github.com/ethz-asl/rotors_simulator/blob/master/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp

--- a/src/AirPressureSensor.cc
+++ b/src/AirPressureSensor.cc
@@ -159,7 +159,7 @@ bool AirPressureSensor::Update(const ignition::common::Time &_now)
   msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->FrameID());
+  frame->add_value(this->FrameId());
 
   // This block of code comes from RotorS:
   // https://github.com/ethz-asl/rotors_simulator/blob/master/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp

--- a/src/AltimeterSensor.cc
+++ b/src/AltimeterSensor.cc
@@ -147,7 +147,7 @@ bool AltimeterSensor::Update(const ignition::common::Time &_now)
   msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->FrameID());
+  frame->add_value(this->FrameId());
 
   // Apply altimeter vertical position noise
   if (this->dataPtr->noises.find(ALTIMETER_VERTICAL_POSITION_NOISE_METERS) !=

--- a/src/AltimeterSensor.cc
+++ b/src/AltimeterSensor.cc
@@ -147,7 +147,7 @@ bool AltimeterSensor::Update(const ignition::common::Time &_now)
   msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->Name());
+  frame->add_value(this->FrameID());
 
   // Apply altimeter vertical position noise
   if (this->dataPtr->noises.find(ALTIMETER_VERTICAL_POSITION_NOISE_METERS) !=

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -400,7 +400,7 @@ bool CameraSensor::Update(const ignition::common::Time &_now)
     msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
     auto frame = msg.mutable_header()->add_data();
     frame->set_key("frame_id");
-    frame->add_value(this->Name());
+    frame->add_value(this->FrameID());
     msg.set_data(data, this->dataPtr->camera->ImageMemorySize());
   }
 
@@ -606,7 +606,7 @@ void CameraSensor::PopulateInfo(const sdf::Camera *_cameraSdf)
   // can populate it with arbitrary frames.
   auto infoFrame = this->dataPtr->infoMsg.mutable_header()->add_data();
   infoFrame->set_key("frame_id");
-  infoFrame->add_value(this->Name());
+  infoFrame->add_value(this->FrameID());
 
   this->dataPtr->infoMsg.set_width(width);
   this->dataPtr->infoMsg.set_height(height);

--- a/src/CameraSensor.cc
+++ b/src/CameraSensor.cc
@@ -400,7 +400,7 @@ bool CameraSensor::Update(const ignition::common::Time &_now)
     msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
     auto frame = msg.mutable_header()->add_data();
     frame->set_key("frame_id");
-    frame->add_value(this->FrameID());
+    frame->add_value(this->FrameId());
     msg.set_data(data, this->dataPtr->camera->ImageMemorySize());
   }
 
@@ -606,7 +606,7 @@ void CameraSensor::PopulateInfo(const sdf::Camera *_cameraSdf)
   // can populate it with arbitrary frames.
   auto infoFrame = this->dataPtr->infoMsg.mutable_header()->add_data();
   infoFrame->set_key("frame_id");
-  infoFrame->add_value(this->FrameID());
+  infoFrame->add_value(this->FrameId());
 
   this->dataPtr->infoMsg.set_width(width);
   this->dataPtr->infoMsg.set_height(height);

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -543,7 +543,7 @@ bool DepthCameraSensor::Update(const ignition::common::Time &_now)
   msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->FrameID());
+  frame->add_value(this->FrameId());
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   msg.set_data(this->dataPtr->depthBuffer,

--- a/src/DepthCameraSensor.cc
+++ b/src/DepthCameraSensor.cc
@@ -543,7 +543,7 @@ bool DepthCameraSensor::Update(const ignition::common::Time &_now)
   msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->Name());
+  frame->add_value(this->FrameID());
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   msg.set_data(this->dataPtr->depthBuffer,

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -216,7 +216,7 @@ bool ImuSensor::Update(const ignition::common::Time &_now)
   msg.set_entity_name(this->Name());
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->Name());
+  frame->add_value(this->FrameID());
 
   msgs::Set(msg.mutable_orientation(), this->dataPtr->orientation);
   msgs::Set(msg.mutable_angular_velocity(), this->dataPtr->angularVel);

--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -216,7 +216,7 @@ bool ImuSensor::Update(const ignition::common::Time &_now)
   msg.set_entity_name(this->Name());
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->FrameID());
+  frame->add_value(this->FrameId());
 
   msgs::Set(msg.mutable_orientation(), this->dataPtr->orientation);
   msgs::Set(msg.mutable_angular_velocity(), this->dataPtr->angularVel);

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -232,7 +232,8 @@ bool Lidar::PublishLidarScan(const ignition::common::Time &_now)
   auto frame = this->dataPtr->laserMsg.mutable_header()->add_data();
   frame->set_key("frame_id");
   // keeping here the sensor name instead of frame_id because the visualizeLidar
-  // plugin relies on this value to get the position of the lidar
+  // plugin relies on this value to get the position of the lidar.
+  // the ros_ign plugin is using the laserscan.proto 'frame' field
   frame->add_value(this->Name());
   this->dataPtr->laserMsg.set_frame(this->FrameID());
 

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -45,9 +45,6 @@ class ignition::sensors::LidarPrivate
 
   /// \brief Sdf sensor.
   public: sdf::Lidar sdfLidar;
-
-  /// \brief frame id
-  public: std::string frame_id;
 };
 
 //////////////////////////////////////////////////
@@ -169,16 +166,6 @@ bool Lidar::Load(const sdf::Sensor &_sdf)
     }
   }
 
-  sdf::ElementPtr element = _sdf.Element();
-  if (element->HasElement("frame_id"))
-  {
-    this->dataPtr->frame_id = element->Get<std::string>("frame_id");
-  }
-  else
-  {
-    this->dataPtr->frame_id = this->Name();
-  }
-
   this->initialized = true;
   return true;
 }
@@ -244,8 +231,10 @@ bool Lidar::PublishLidarScan(const ignition::common::Time &_now)
   this->dataPtr->laserMsg.mutable_header()->clear_data();
   auto frame = this->dataPtr->laserMsg.mutable_header()->add_data();
   frame->set_key("frame_id");
+  // keeping here the sensor name instead of frame_id because the visualizeLidar
+  // plugin relies on this value to get the position of the lidar
   frame->add_value(this->Name());
-  this->dataPtr->laserMsg.set_frame(this->dataPtr->frame_id);
+  this->dataPtr->laserMsg.set_frame(this->FrameID());
 
   // Store the latest laser scans into laserMsg
   msgs::Set(this->dataPtr->laserMsg.mutable_world_pose(),

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -170,7 +170,6 @@ bool Lidar::Load(const sdf::Sensor &_sdf)
   }
 
   sdf::ElementPtr element = _sdf.Element();
-  // Get the background color, if specified.
   if (element->HasElement("frame_id"))
   {
     this->dataPtr->frame_id = element->Get<std::string>("frame_id");

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -45,6 +45,9 @@ class ignition::sensors::LidarPrivate
 
   /// \brief Sdf sensor.
   public: sdf::Lidar sdfLidar;
+
+  /// \brief frame id
+  public: std::string frame_id;
 };
 
 //////////////////////////////////////////////////
@@ -166,6 +169,17 @@ bool Lidar::Load(const sdf::Sensor &_sdf)
     }
   }
 
+  sdf::ElementPtr element = _sdf.Element();
+  // Get the background color, if specified.
+  if (element->HasElement("frame_id"))
+  {
+    this->dataPtr->frame_id = element->Get<std::string>("frame_id");
+  }
+  else
+  {
+    this->dataPtr->frame_id = this->Name();
+  }
+
   this->initialized = true;
   return true;
 }
@@ -232,7 +246,7 @@ bool Lidar::PublishLidarScan(const ignition::common::Time &_now)
   auto frame = this->dataPtr->laserMsg.mutable_header()->add_data();
   frame->set_key("frame_id");
   frame->add_value(this->Name());
-  this->dataPtr->laserMsg.set_frame(this->Name());
+  this->dataPtr->laserMsg.set_frame(this->dataPtr->frame_id);
 
   // Store the latest laser scans into laserMsg
   msgs::Set(this->dataPtr->laserMsg.mutable_world_pose(),

--- a/src/Lidar.cc
+++ b/src/Lidar.cc
@@ -235,7 +235,7 @@ bool Lidar::PublishLidarScan(const ignition::common::Time &_now)
   // plugin relies on this value to get the position of the lidar.
   // the ros_ign plugin is using the laserscan.proto 'frame' field
   frame->add_value(this->Name());
-  this->dataPtr->laserMsg.set_frame(this->FrameID());
+  this->dataPtr->laserMsg.set_frame(this->FrameId());
 
   // Store the latest laser scans into laserMsg
   msgs::Set(this->dataPtr->laserMsg.mutable_world_pose(),

--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -166,7 +166,7 @@ bool LogicalCameraSensor::Update(const ignition::common::Time &_now)
   this->dataPtr->msg.mutable_header()->clear_data();
   auto frame = this->dataPtr->msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->Name());
+  frame->add_value(this->FrameID());
 
   // publish
   this->AddSequence(this->dataPtr->msg.mutable_header());

--- a/src/LogicalCameraSensor.cc
+++ b/src/LogicalCameraSensor.cc
@@ -166,7 +166,7 @@ bool LogicalCameraSensor::Update(const ignition::common::Time &_now)
   this->dataPtr->msg.mutable_header()->clear_data();
   auto frame = this->dataPtr->msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->FrameID());
+  frame->add_value(this->FrameId());
 
   // publish
   this->AddSequence(this->dataPtr->msg.mutable_header());

--- a/src/MagnetometerSensor.cc
+++ b/src/MagnetometerSensor.cc
@@ -168,7 +168,7 @@ bool MagnetometerSensor::Update(const ignition::common::Time &_now)
   msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->Name());
+  frame->add_value(this->FrameID());
 
   // Apply magnetometer noise after converting to body frame
   if (this->dataPtr->noises.find(MAGNETOMETER_X_NOISE_TESLA) !=

--- a/src/MagnetometerSensor.cc
+++ b/src/MagnetometerSensor.cc
@@ -168,7 +168,7 @@ bool MagnetometerSensor::Update(const ignition::common::Time &_now)
   msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
   auto frame = msg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->FrameID());
+  frame->add_value(this->FrameId());
 
   // Apply magnetometer noise after converting to body frame
   if (this->dataPtr->noises.find(MAGNETOMETER_X_NOISE_TESLA) !=

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -468,7 +468,7 @@ bool RgbdCameraSensor::Update(const ignition::common::Time &_now)
     msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
     auto frame = msg.mutable_header()->add_data();
     frame->set_key("frame_id");
-    frame->add_value(this->FrameID());
+    frame->add_value(this->FrameId());
 
     std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
@@ -583,7 +583,7 @@ bool RgbdCameraSensor::Update(const ignition::common::Time &_now)
       msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
       auto frame = msg.mutable_header()->add_data();
       frame->set_key("frame_id");
-      frame->add_value(this->FrameID());
+      frame->add_value(this->FrameId());
       msg.set_data(data, rendering::PixelUtil::MemorySize(rendering::PF_R8G8B8,
         width, height));
 

--- a/src/RgbdCameraSensor.cc
+++ b/src/RgbdCameraSensor.cc
@@ -468,7 +468,7 @@ bool RgbdCameraSensor::Update(const ignition::common::Time &_now)
     msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
     auto frame = msg.mutable_header()->add_data();
     frame->set_key("frame_id");
-    frame->add_value(this->Name());
+    frame->add_value(this->FrameID());
 
     std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
@@ -583,7 +583,7 @@ bool RgbdCameraSensor::Update(const ignition::common::Time &_now)
       msg.mutable_header()->mutable_stamp()->set_nsec(_now.nsec);
       auto frame = msg.mutable_header()->add_data();
       frame->set_key("frame_id");
-      frame->add_value(this->Name());
+      frame->add_value(this->FrameID());
       msg.set_data(data, rendering::PixelUtil::MemorySize(rendering::PF_R8G8B8,
         width, height));
 

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -125,13 +125,16 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
   }
 
   sdf::ElementPtr element = _sdf.Element();
-  if (element->HasElement("ignition:frame_id"))
+  if (element)
   {
-    this->frame_id = element->Get<std::string>("ignition:frame_id");
-  }
-  else
-  {
-    this->frame_id = this->name;
+    if (element->HasElement("ignition:frame_id"))
+    {
+      this->frame_id = element->Get<std::string>("ignition:frame_id");
+    }
+    else
+    {
+      this->frame_id = this->name;
+    }
   }
 
   // Try resolving the pose first, and only use the raw pose if that fails

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -127,9 +127,9 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
   sdf::ElementPtr element = _sdf.Element();
   if (element)
   {
-    if (element->HasElement("ignition:frame_id"))
+    if (element->HasElement("ignition_frame_id"))
     {
-      this->frame_id = element->Get<std::string>("ignition:frame_id");
+      this->frame_id = element->Get<std::string>("ignition_frame_id");
     }
     else
     {
@@ -209,10 +209,17 @@ std::string Sensor::Name() const
 }
 
 //////////////////////////////////////////////////
-std::string Sensor::FrameID() const
+std::string Sensor::FrameId() const
 {
   return this->dataPtr->frame_id;
 }
+
+//////////////////////////////////////////////////
+void Sensor::SetFrameId(const std::string &_frameId)
+{
+  this->dataPtr->frame_id = _frameId;
+}
+
 //////////////////////////////////////////////////
 std::string Sensor::Topic() const
 {

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -91,6 +91,9 @@ class ignition::sensors::SensorPrivate
   /// A map is used so that a single sensor can have multiple sensor
   /// streams each with a sequence counter.
   public: std::map<std::string, uint64_t> sequences;
+
+  /// \brief frame id
+  public: std::string frame_id;
 };
 
 SensorId SensorPrivate::idCounter = 0;
@@ -119,6 +122,16 @@ bool SensorPrivate::PopulateFromSDF(const sdf::Sensor &_sdf)
   {
     if (!this->SetTopic(_sdf.Topic()))
       return false;
+  }
+
+  sdf::ElementPtr element = _sdf.Element();
+  if (element->HasElement("ignition:frame_id"))
+  {
+    this->frame_id = element->Get<std::string>("ignition:frame_id");
+  }
+  else
+  {
+    this->frame_id = this->name;
   }
 
   // Try resolving the pose first, and only use the raw pose if that fails
@@ -192,6 +205,11 @@ std::string Sensor::Name() const
   return this->dataPtr->name;
 }
 
+//////////////////////////////////////////////////
+std::string Sensor::FrameID() const
+{
+  return this->dataPtr->frame_id;
+}
 //////////////////////////////////////////////////
 std::string Sensor::Topic() const
 {

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -88,6 +88,10 @@ TEST(Sensor_TEST, Sensor)
   EXPECT_EQ(1u, sensor.Id());
 
   EXPECT_EQ(nullptr, sensor.SDF());
+
+  EXPECT_EQ(sensor.Name(), sensor.FrameId());
+  sensor.SetFrameId("frame_id_12");
+  EXPECT_EQ(std::string("frame_id_12"), sensor.FrameId());
 }
 
 //////////////////////////////////////////////////

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -414,7 +414,7 @@ bool ThermalCameraSensor::Update(const ignition::common::Time &_now)
   stamp->set_nsec(_now.nsec);
   auto frame = this->dataPtr->thermalMsg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->FrameID());
+  frame->add_value(this->FrameId());
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   this->dataPtr->thermalMsg.set_data(this->dataPtr->thermalBuffer,

--- a/src/ThermalCameraSensor.cc
+++ b/src/ThermalCameraSensor.cc
@@ -414,7 +414,7 @@ bool ThermalCameraSensor::Update(const ignition::common::Time &_now)
   stamp->set_nsec(_now.nsec);
   auto frame = this->dataPtr->thermalMsg.mutable_header()->add_data();
   frame->set_key("frame_id");
-  frame->add_value(this->Name());
+  frame->add_value(this->FrameID());
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   this->dataPtr->thermalMsg.set_data(this->dataPtr->thermalBuffer,

--- a/test/integration/camera_plugin.cc
+++ b/test/integration/camera_plugin.cc
@@ -95,6 +95,8 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
   EXPECT_EQ(256u, sensor->ImageWidth());
   EXPECT_EQ(257u, sensor->ImageHeight());
 
+  EXPECT_EQ(std::string("base_camera"), sensor->FrameId());
+
   std::string topic = "/test/integration/CameraPlugin_imagesWithBuiltinSDF";
   WaitForMessageTestHelper<ignition::msgs::Image> helper(topic);
 

--- a/test/integration/camera_sensor_builtin.sdf
+++ b/test/integration/camera_sensor_builtin.sdf
@@ -4,6 +4,7 @@
     <link name="link1">
       <sensor name="camera1" type="camera">
         <update_rate>10</update_rate>
+        <ignition_frame_id>base_camera</ignition_frame_id>
         <topic>/test/integration/CameraPlugin_imagesWithBuiltinSDF</topic>
         <camera>
           <horizontal_fov>1.05</horizontal_fov>


### PR DESCRIPTION
# 🎉 New feature

## Summary

While I was giving [support for the turtlebot3 in Ignition](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/pull/180) , I found that the `frame_id` is generated with this format `<model_name>::<link_name>::<sensor_bane>`, then when we use the bridge to republish the data in the ROS network, the `frame_id` is modified [here](
https://github.com/ignitionrobotics/ros_ign/blob/8f01ea1dc3767509161d106e62dbb53306b153aa/ros_ign_bridge/src/convert.cpp#L56-L59) and it will look like `<model_name>/<link_name>/<sensor_bane>`, but this format is still not valid, it not matching with any `frame_id` in `tf`. 

This PR overwrite the `frame_id` value and set it to another value which allows to make it compatible with ROS.

I don't know where is the right place to document this.

## Test it

Following the steps in the other PR you can test this.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
