### PR TITLE
Add API to set next sensor update time

### DIFF
--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -99,6 +99,13 @@ namespace ignition
       /// \brief Return the next time the sensor will generate data
       public: std::chrono::steady_clock::duration NextDataUpdateTime() const;
 
+      /// \brief Manually set the next time the sensor will generate data
+      /// Useful for accomodating jumps backwards in time as well
+      /// as specifying updates for non-uniformly updating sensors
+      /// \param[in] _time The next update time
+      public: void SetNextDataUpdateTime(
+                  const std::chrono::steady_clock::duration &_time);
+
       /// \brief Update the sensor.
       ///
       ///   This is called by the manager, and is responsible for determining

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -433,7 +433,14 @@ bool Sensor::Update(const std::chrono::steady_clock::duration &_now,
     // Update the time the plugin should be loaded
     auto delta = std::chrono::duration_cast< std::chrono::milliseconds>
       (std::chrono::duration< double >(1.0 / this->dataPtr->updateRate));
+
     this->dataPtr->nextUpdateTime += delta;
+
+    // Catch up to "now", if necessary.
+    while (this->dataPtr->nextUpdateTime <= _now)
+    {
+      this->dataPtr->nextUpdateTime += delta;
+    }
   }
 
   return result;
@@ -443,6 +450,13 @@ bool Sensor::Update(const std::chrono::steady_clock::duration &_now,
 std::chrono::steady_clock::duration Sensor::NextDataUpdateTime() const
 {
   return this->dataPtr->nextUpdateTime;
+}
+
+//////////////////////////////////////////////////
+void Sensor::SetNextDataUpdateTime(
+    const std::chrono::steady_clock::duration &_time)
+{
+  this->dataPtr->nextUpdateTime = _time;
 }
 
 /////////////////////////////////////////////////

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -401,9 +401,9 @@ TEST_F(SensorUpdate, NextDataUpdateTime)
     sensor->SetNextDataUpdateTime(next);
     EXPECT_TRUE(sensor->Update(now, false));
 
-    // The next update should the the first dt past the current time
-    std::chrono::steady_clock::duration new_next = std::chrono::seconds(6);
-    EXPECT_EQ(new_next.count(), sensor->NextDataUpdateTime().count());
+    // The next update should be the first dt past the current time
+    std::chrono::steady_clock::duration newNext = std::chrono::seconds(6);
+    EXPECT_EQ(newNext.count(), sensor->NextDataUpdateTime().count());
   }
 }
 


### PR DESCRIPTION
# 🎉 API for setting next update time

## Summary

This method allows external uers to set the next update time for a sensor. 

One potential application:
* Sensors that have irregular update times that don't follow a `dt`

This fixes two issues with time and sensors:
* Large jumps forward in time will cause sensors to update too much to "catch up" to the current time, as the next time was only ever incremented by `dt`
* Large jumps backward in time will cause sensors to stop updating until the reach "nextupdatetime"

## Test it

See the unit tests for intended behaviors.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

