### PR TITLE
Use pose multiplication instead of addition

### DIFF
--- a/test/integration/air_pressure.cc
+++ b/test/integration/air_pressure.cc
@@ -192,8 +192,8 @@ TEST_F(AirPressureSensorTest, SensorReadings)
   EXPECT_DOUBLE_EQ(vertRef, sensor->ReferenceAltitude());
   EXPECT_DOUBLE_EQ(vertRef, sensorNoise->ReferenceAltitude());
 
-  sensor->SetPose(sensorNoise->Pose() +
-      ignition::math::Pose3d(0, 0, 1.5, 0, 0, 0));
+  sensor->SetPose(
+      ignition::math::Pose3d(0, 0, 1.5, 0, 0, 0) * sensorNoise->Pose());
 
   // verify msg received on the topic
   WaitForMessageTestHelper<ignition::msgs::FluidPressure> msgHelper(topic);


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignitionrobotics/ign-math/issues/60

## Summary

The ign-math Pose addition operator is going to be deprecated, so use the multiplication operator instead. It works in the opposite order, matching the behavior of coordinate transform multiplication. The deprecation is planned for ignition-math7, which will not affect Fortress, but I've targeted this branch to reduce the chance of conflicts when merging forward.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
