### PR TITLE
Add function for enabling / disabling a sensor

### DIFF
--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -213,7 +213,8 @@ namespace ignition
       public: bool IsActive() const;
 
       /// \brief Enable or disable the sensor. Disabled sensors will not
-      /// generate or publish data.
+      /// generate or publish data unless Update is called with the
+      /// '_force' argument set to true.
       /// \param[in] _active True to set the sensor to be active,
       /// false to disable the sensor.
       /// \sa IsActive

--- a/include/ignition/sensors/Sensor.hh
+++ b/include/ignition/sensors/Sensor.hh
@@ -207,6 +207,18 @@ namespace ignition
       public: void PublishMetrics(
         const std::chrono::duration<double> &_now);
 
+      /// \brief Get whether the sensor is enabled or not
+      /// \return True if the sensor is active, false otherwise.
+      /// \sa SetActive
+      public: bool IsActive() const;
+
+      /// \brief Enable or disable the sensor. Disabled sensors will not
+      /// generate or publish data.
+      /// \param[in] _active True to set the sensor to be active,
+      /// false to disable the sensor.
+      /// \sa IsActive
+      public: void SetActive(bool _active);
+
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \internal
       /// \brief Data pointer for private data

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -109,6 +109,9 @@ class ignition::sensors::SensorPrivate
 
   /// \brief frame id
   public: std::string frame_id;
+
+  /// \brief If sensor is active or not.
+  public: bool active = true;
 };
 
 SensorId SensorPrivate::idCounter = 0;
@@ -446,6 +449,10 @@ bool Sensor::Update(const std::chrono::steady_clock::duration &_now,
     return result;
   }
 
+  // prevent update if not active, unless forced
+  if (!this->dataPtr->active && !_force)
+    return result;
+
   // Make the update happen
   result = this->Update(_now);
 
@@ -501,4 +508,16 @@ void Sensor::AddSequence(ignition::msgs::Header *_msg,
   ignition::msgs::Header::Map *map = _msg->add_data();
   map->set_key("seq");
   map->add_value(value);
+}
+
+/////////////////////////////////////////////////
+bool Sensor::IsActive() const
+{
+  return this->dataPtr->active;
+}
+
+/////////////////////////////////////////////////
+void Sensor::SetActive(bool _active)
+{
+  this->dataPtr->active = _active;
 }

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -92,6 +92,10 @@ TEST(Sensor_TEST, Sensor)
   EXPECT_EQ(sensor.Name(), sensor.FrameId());
   sensor.SetFrameId("frame_id_12");
   EXPECT_EQ(std::string("frame_id_12"), sensor.FrameId());
+
+  EXPECT_TRUE(sensor.IsActive());
+  sensor.SetActive(false);
+  EXPECT_FALSE(sensor.IsActive());
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/TransportTestTools.hh
+++ b/test/integration/TransportTestTools.hh
@@ -65,8 +65,10 @@ class WaitForMessageTestHelper
 
   /// \brief waits for a message to be received with a timeout
   /// \return true if a message was received
+  /// \param[in] _timeout Time to wait for a message.
   /// \remarks Set CTest timeout property for control over time
-  public: bool WaitForMessage(const std::chrono::steady_clock::duration _timeout)
+  public: bool WaitForMessage(
+      const std::chrono::steady_clock::duration &_timeout)
   {
     std::unique_lock<std::mutex> lock(this->mtx);
     if (this->subscriptionCreated)

--- a/test/integration/TransportTestTools.hh
+++ b/test/integration/TransportTestTools.hh
@@ -63,6 +63,22 @@ class WaitForMessageTestHelper
     return success;
   }
 
+  /// \brief waits for a message to be received with a timeout
+  /// \return true if a message was received
+  /// \remarks Set CTest timeout property for control over time
+  public: bool WaitForMessage(const std::chrono::steady_clock::duration _timeout)
+  {
+    std::unique_lock<std::mutex> lock(this->mtx);
+    if (this->subscriptionCreated)
+    {
+      this->conditionVariable.wait_for(lock, _timeout,
+          [this]{return this->gotMessage;});
+    }
+    bool success = this->gotMessage;
+    this->gotMessage = false;
+    return success;
+  }
+
   /// \brief Get the last msg received.
   /// \return last msg received.
   public: M Message()

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -111,6 +111,22 @@ void CameraSensorTest::ImagesWithBuiltinSDF(const std::string &_renderEngine)
 
   EXPECT_TRUE(helper.WaitForMessage()) << helper;
 
+  // verify sensor does not update / publish data when not active
+  sensor->SetActive(false);
+  EXPECT_FALSE(sensor->IsActive());
+  mgr.RunOnce(std::chrono::seconds(1));
+  EXPECT_FALSE(helper.WaitForMessage(std::chrono::seconds(3))) << helper;
+
+  // sensor should update when forced even if it is not active
+  mgr.RunOnce(std::chrono::seconds(1), true);
+  EXPECT_TRUE(helper.WaitForMessage(std::chrono::seconds(3))) << helper;
+
+  // make the sensor active again and verify data is published
+  sensor->SetActive(true);
+  EXPECT_TRUE(sensor->IsActive());
+  mgr.RunOnce(std::chrono::seconds(2));
+  EXPECT_TRUE(helper.WaitForMessage(std::chrono::seconds(3))) << helper;
+
   // test removing sensor
   // first make sure the sensor objects do exist
   auto sensorId = sensor->Id();


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

Added `SetActive` and `IsActive` function for enabling and disabling a sensor.

The sensor is active by default. A disabled / non-active sensor will not generate or publish data when the `Update` function is called. It will however update if the `force` argument is true, similar to the behavior in [gazebo-classic](https://github.com/osrf/gazebo/blob/gazebo11/gazebo/sensors/Sensor.cc#L237). 

## Test it

Run the `INTEGRATION_camera` test.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
