### PR TITLE
Check if Distortion / noise render pass is null before setting it

### DIFF
--- a/src/ImageBrownDistortionModel.cc
+++ b/src/ImageBrownDistortionModel.cc
@@ -107,6 +107,12 @@ void ImageBrownDistortionModel::SetCamera(rendering::CameraPtr _camera)
     // add distortion pass
     rendering::RenderPassPtr distortionPass =
       rpSystem->Create<rendering::DistortionPass>();
+    if (!distortionPass)
+    {
+      ignwarn << "ImageBrownDistortionModel is not supported in "
+              << engine->Name() << std::endl;
+      return;
+    }
     this->dataPtr->distortionPass =
         std::dynamic_pointer_cast<rendering::DistortionPass>(distortionPass);
     this->dataPtr->distortionPass->SetK1(this->dataPtr->k1);

--- a/src/ImageGaussianNoiseModel.cc
+++ b/src/ImageGaussianNoiseModel.cc
@@ -93,6 +93,12 @@ void ImageGaussianNoiseModel::SetCamera(rendering::CameraPtr _camera)
     // add gaussian noise pass
     rendering::RenderPassPtr noisePass =
       rpSystem->Create<rendering::GaussianNoisePass>();
+    if (!noisePass)
+    {
+      ignwarn << "ImageGaussianNoiseModel is not supported in "
+             << engine->Name() << std::endl;
+      return;
+    }
     this->dataPtr->gaussianNoisePass =
         std::dynamic_pointer_cast<rendering::GaussianNoisePass>(noisePass);
     this->dataPtr->gaussianNoisePass->SetMean(this->dataPtr->mean);


### PR DESCRIPTION
# 🦟 Bug fix

The distortion / noise model pointer returned could be null because ign-rendering does not support it.

For example, distortion is supported in ogre 1.x but not ogre 2.x. So when ign-gazebo tries to load an ogre 2.x scene with camera distortion, it'll lead to a crash


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.


