### PR TITLE
custom_rpy parent_frame should be set to 'world' in IMUs

### DIFF
--- a/src/ImuSensor.cc
+++ b/src/ImuSensor.cc
@@ -321,14 +321,14 @@ void ImuSensor::SetWorldFrameOrientation(
   // Set orientation reference frame if custom_rpy was supplied
   if (this->dataPtr->sensorOrientationRelativeTo == WorldFrameEnumType::CUSTOM)
   {
-    if (this->dataPtr->customRpyParentFrame == "")
+    if (this->dataPtr->customRpyParentFrame == "world")
     {
       this->SetOrientationReference(this->dataPtr->worldRelativeOrientation *
         this->dataPtr->customRpyQuaternion);
     }
     else
     {
-      ignwarn << "custom_rpy parent frame must be set to empty "
+      ignwarn << "custom_rpy parent frame must be set to 'world' "
                 "string. Setting it to any other frame is not "
                 "supported yet." << std::endl;
     }

--- a/src/ImuSensor_TEST.cc
+++ b/src/ImuSensor_TEST.cc
@@ -411,7 +411,7 @@ TEST(ImuSensor_TEST, OrientationReference)
     << "      <imu>"
     << "      <orientation_reference_frame>"
     << "      <localization>CUSTOM</localization>"
-    << "      <custom_rpy>1.570795 0 0</custom_rpy>"
+    << "      <custom_rpy parent_frame='world'>1.570795 0 0</custom_rpy>"
     << "      </orientation_reference_frame>"
     << "      </imu>"
     << "      <always_on>1</always_on>"
@@ -507,7 +507,7 @@ TEST(ImuSensor_TEST, CustomRpyParentFrame)
   sensor->Update(std::chrono::steady_clock::duration(
     std::chrono::nanoseconds(10000000)));
 
-  // Since parent_frame is not set to empty in the sdf,
+  // Since parent_frame is not set to 'world' in the sdf,
   // custom_rpy will be rejected and reference orientation will
   // not be set.
   math::Quaterniond orientValue(math::Vector3d(-1.570795, 0, 0));


### PR DESCRIPTION
Signed-off-by: Aditya <aditya050995@gmail.com>

# 🦟 Bug fix

## Summary
Originally, the ``custom_rpy`` orientation reference frame for IMUs, added here : https://github.com/ignitionrobotics/ign-sensors/pull/186, accepts a ``parent_frame`` w.r.t which the roll, pitch, yaw are applied. If left blank, this should default to the sensor's parent frame (http://sdformat.org/spec?ver=1.9&elem=sensor#custom_rpy_parent_frame), whereas in the current implementation it defaults to world frame. 

It is not possible to support every possible parent fame for now and only the 'world' can be set as the parent frame, due to limitations with sdf parsing. This PR makes ``custom_rpy`` only accept ``world`` as a parent frame, and anything else is rejected for now. Check this for the original discussion : https://github.com/ignitionrobotics/ign-gazebo/pull/1320#discussion_r840188318 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

